### PR TITLE
better package install experience with uv+pip, no conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ### Default Installation (Batteries Included)
 
-The default installation includes core functionality plus CLI tools:
+The default installation includes core functionality, CLI tools, and data conversion capabilities:
 
 ```bash
 # Using uv (recommended)
@@ -37,15 +37,13 @@ uv add slafdb
 
 # Or pip
 pip install slafdb
-
-# Or conda
-conda install -c conda-forge slafdb
 ```
 
 **What's included by default:**
 
 - ✅ Core SLAF functionality (SQL queries, data structures)
 - ✅ CLI tools (`slaf convert`, `slaf query`, etc.)
+- ✅ Data conversion tools (scanpy, h5py for h5ad files)
 - ✅ Rich console output and progress bars
 - ✅ Cross-platform compatibility
 
@@ -53,7 +51,6 @@ conda install -c conda-forge slafdb
 
 Dependencies for:
 
-- ❌ Data conversion tools (scanpy, h5py)
 - ❌ Machine learning features (PyTorch tokenizers)
 - ❌ Advanced single-cell tools (igraph, leidenalg)
 
@@ -88,17 +85,6 @@ uv add slafdb
 uv add slafdb
 ```
 
-**Option 3: Use conda with manual polars specification**
-
-```bash
-# For macOS Apple Silicon
-conda install -c conda-forge polars-lts-cpu
-conda install -c conda-forge slafdb
-
-# For Linux/Windows
-conda install -c conda-forge slafdb
-```
-
 **Note**: Package managers don't automatically choose between `polars` and `polars-lts-cpu` - you may need to specify the correct version for your platform.
 
 ### Optional Dependencies
@@ -108,7 +94,6 @@ Add specific features as needed:
 **Using uv:**
 
 ```bash
-uv add "slafdb[convert]"
 uv add "slafdb[ml]"
 uv add "slafdb[advanced]"
 uv add "slafdb[full]"
@@ -118,20 +103,10 @@ uv add "slafdb[dev]"
 **Using pip:**
 
 ```bash
-pip install slafdb[convert]
 pip install slafdb[ml]
 pip install slafdb[advanced]
 pip install slafdb[full]
 pip install slafdb[dev]
-```
-
-**Using conda:**
-
-```bash
-# Note: conda may not support all optional dependency groups
-# You may need to install additional packages manually
-conda install -c conda-forge slafdb
-pip install slafdb[convert]  # For optional dependencies
 ```
 
 ### Development Installation
@@ -146,7 +121,7 @@ uv add --extra dev --extra test --extra docs
 
 ### Converting Your Data
 
-First, convert your existing single-cell data to SLAF format:
+Convert your existing single-cell data to SLAF format - **no extra dependencies required!**
 
 ```bash
 # Convert AnnData (.h5ad) to SLAF
@@ -360,7 +335,7 @@ for batch in dataloader:
 ### Data Conversion
 
 ```bash
-# Convert AnnData to SLAF
+# Convert AnnData to SLAF (included by default)
 slaf convert input.h5ad output.slaf
 
 # Convert HDF5 to SLAF

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -12,9 +12,6 @@ uv add slafdb
 
 # Or pip
 pip install slafdb
-
-# Or conda
-conda install -c conda-forge slafdb
 ```
 
 For development dependencies (including documentation):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ dependencies = [
     "pyarrow>=20.0.0", # Data conversion in data/converter.py
     "scipy>=1.15.0",   # Sparse operations in core and data
     "loguru>=0.7.0",   # Logging functionality across all modules
+    # Data conversion - essential for CLI functionality
+    "scanpy>=1.11.2",   # For h5ad file conversion
+    "h5py>=3.10.0",     # For chunked H5AD reading
+    "requests>=2.32.4", # For downloading datasets
     # CLI and utilities
     "typer>=0.9.0", # CLI framework
     "rich>=14.0.0", # Rich console output
@@ -24,13 +28,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Data conversion - for converting data formats
-convert = [
-    "scanpy>=1.11.2",
-    "h5py>=3.10.0",     # For chunked H5AD reading
-    "requests>=2.32.4", # For downloading datasets
-]
-
 # Machine learning - for ML modules
 ml = ["torch>=2.7.1"]
 
@@ -86,7 +83,7 @@ test = [
 ]
 
 # Full installation includes all optional dependencies
-full = ["slafdb[convert,ml,advanced]"]
+full = ["slafdb[ml,advanced]"]
 
 [project.scripts]
 slaf = "slaf.cli:app"
@@ -97,7 +94,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["slaf"]
+include = ["slaf*"]
 
 [tool.ruff]
 target-version = "py312"

--- a/slaf/__init__.py
+++ b/slaf/__init__.py
@@ -1,7 +1,7 @@
 try:
     from importlib.metadata import version
 
-    __version__ = version("slaf")
+    __version__ = version("slafdb")
 except ImportError:
     __version__ = "unknown"
 

--- a/slaf/data/converter.py
+++ b/slaf/data/converter.py
@@ -16,7 +16,7 @@ try:
     SCANPY_AVAILABLE = True
 except ImportError:
     SCANPY_AVAILABLE = False
-    logger.warning("Scanpy not available. Install with: pip install slafdb[convert]")
+    logger.warning("Scanpy not available. Install with: pip install scanpy")
 
 from .chunked_reader import create_chunked_reader
 from .utils import detect_format
@@ -213,7 +213,7 @@ class SLAFConverter:
             if not SCANPY_AVAILABLE:
                 raise ImportError(
                     "Scanpy is required for h5ad conversion. "
-                    "Install with: pip install slafdb[convert]"
+                    "Install with: pip install scanpy"
                 )
             self._convert_h5ad(input_path, output_path)
         elif input_format == "10x_mtx":


### PR DESCRIPTION
Addresses installation issues in #5 
- makes include paths correct
- makes convert dependencies part of the default experience
- removes references to conda in installation since package is not part of conda yet