### PR TITLE
update scdataset benchmarks with the correct callbacks

### DIFF
--- a/benchmarks/benchmark_scdataset_multiprocessing.py
+++ b/benchmarks/benchmark_scdataset_multiprocessing.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""
+scDataset Multiprocessing Benchmark
+
+This benchmark tests scDataset performance scaling with different num_workers values.
+Uses fixed block_size=4 and fetch_factor=16 as optimal parameters from the paper.
+"""
+
+import gc
+import time
+from dataclasses import dataclass
+
+import anndata as ad
+import psutil
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from tqdm import tqdm
+
+from slaf.core.slaf import SLAFArray
+
+
+# Define the fetch_transform callback for AnnData at module level
+def fetch_transform_adata(batch):
+    """Callback function to transform scDataset batches to AnnData format."""
+    return batch.to_adata()
+
+
+@dataclass
+class MultiprocessingBenchmarkResult:
+    """Results from scDataset multiprocessing benchmark."""
+
+    num_workers: int
+    throughput_cells_per_sec: float
+    memory_usage_gb: float
+    measurement_time: float
+    total_cells: int
+    batches_processed: int
+
+
+class scDatasetMultiprocessingBenchmark:
+    """Benchmark scDataset multiprocessing performance."""
+
+    def __init__(self, slaf_path: str, h5ad_path: str):
+        self.slaf_path = slaf_path
+        self.h5ad_path = h5ad_path
+        self.console = Console()
+
+        # Load SLAF array
+        self.console.print(f"Loading SLAF array from {slaf_path}...")
+        self.slaf_array = SLAFArray(slaf_path)
+
+        # Load AnnData object
+        self.console.print(f"Loading AnnData from {h5ad_path}...")
+        self.adata = ad.read_h5ad(h5ad_path, backed="r")
+        self.console.print(
+            f"Loaded {self.adata.n_obs:,} cells, {self.adata.n_vars:,} genes"
+        )
+
+        # Benchmark parameters
+        self.batch_size = 64
+        self.measurement_duration = 10  # seconds
+
+        # Fixed parameters from paper
+        self.block_size = 4
+        self.fetch_factor = 16
+
+        # num_workers values to test
+        self.num_workers_list = [0, 1, 2, 4, 8]
+
+    def measure_memory_usage_gb(self) -> float:
+        """Get current memory usage in GB."""
+        process = psutil.Process()
+        return process.memory_info().rss / 1024 / 1024 / 1024
+
+    def track_peak_memory(self, duration_seconds: float) -> float:
+        """Track peak memory usage over a duration."""
+        import threading
+
+        peak_memory = 0.0
+        stop_tracking = threading.Event()
+
+        def memory_monitor():
+            nonlocal peak_memory
+            while not stop_tracking.is_set():
+                current_memory = self.measure_memory_usage_gb()
+                peak_memory = max(peak_memory, current_memory)
+                time.sleep(0.1)  # Check every 100ms
+
+        # Start memory monitoring in background thread
+        monitor_thread = threading.Thread(target=memory_monitor)
+        monitor_thread.daemon = True
+        monitor_thread.start()
+
+        # Wait for the specified duration
+        time.sleep(duration_seconds)
+
+        # Stop monitoring
+        stop_tracking.set()
+        monitor_thread.join(timeout=1.0)
+
+        return peak_memory
+
+    def benchmark_with_memory_tracking(
+        self, dataloader, measurement_duration: float, desc: str
+    ):
+        """Run benchmark with memory tracking in parallel and progress bar."""
+        import threading
+
+        peak_memory = 0.0
+        stop_tracking = threading.Event()
+
+        def memory_monitor():
+            nonlocal peak_memory
+            while not stop_tracking.is_set():
+                current_memory = self.measure_memory_usage_gb()
+                peak_memory = max(peak_memory, current_memory)
+                time.sleep(0.1)  # Check every 100ms
+
+        # Start memory monitoring in background thread
+        monitor_thread = threading.Thread(target=memory_monitor)
+        monitor_thread.daemon = True
+        monitor_thread.start()
+
+        # Run the actual benchmark with progress bar
+        start_time = time.time()
+        total_cells = 0
+        batch_count = 0
+
+        with tqdm(desc=desc, unit="batch") as pbar:
+            for _batch in dataloader:
+                batch_start = time.time()
+                batch_count += 1
+
+                # Use actual batch size from the data
+                if isinstance(_batch, dict):
+                    if "X" in _batch:
+                        actual_batch_size = _batch["X"].shape[0]
+                    elif "cell_ids" in _batch:
+                        actual_batch_size = len(_batch["cell_ids"])
+                    else:
+                        actual_batch_size = self.batch_size
+                else:
+                    actual_batch_size = self.batch_size
+                total_cells += actual_batch_size
+
+                # Force actual data loading
+                if hasattr(_batch, "X"):
+                    _ = _batch.X  # Force data loading
+                elif isinstance(_batch, dict) and "X" in _batch:
+                    _ = _batch["X"]  # Force data loading
+
+                batch_end = time.time()
+                _batch_time_ms = (batch_end - batch_start) * 1000
+
+                # Calculate current throughput
+                elapsed = time.time() - start_time
+                current_throughput = total_cells / elapsed if elapsed > 0 else 0
+
+                # Update progress bar
+                pbar.set_postfix(
+                    {
+                        "throughput": f"{current_throughput:.0f} cells/s",
+                        "memory": f"{peak_memory:.1f}GB",
+                    }
+                )
+                pbar.update(1)
+
+                # Stop after measurement duration
+                if elapsed >= measurement_duration:
+                    break
+
+        elapsed_time = time.time() - start_time
+
+        # Stop memory monitoring
+        stop_tracking.set()
+        monitor_thread.join(timeout=1.0)
+
+        return total_cells, batch_count, elapsed_time, peak_memory
+
+    def benchmark_scdataset_multiprocessing(
+        self, num_workers: int
+    ) -> MultiprocessingBenchmarkResult | None:
+        """Benchmark scDataset with specific num_workers value."""
+
+        try:
+            from anndata.experimental import AnnCollection
+            from scdataset import scDataset
+            from torch.utils.data import DataLoader
+        except ImportError:
+            self.console.print(
+                "[yellow]Warning: scDataset not available, skipping benchmark[/yellow]"
+            )
+            return None
+
+        try:
+            # Setup scDataset with optimal parameters from paper
+            collection = AnnCollection([self.adata])
+
+            sc_dataset = scDataset(
+                data_collection=collection,
+                batch_size=self.batch_size,
+                block_size=self.block_size,
+                fetch_factor=self.fetch_factor,
+                fetch_transform=fetch_transform_adata,  # Use module-level callback
+            )
+
+            # Create DataLoader with proper multiprocessing configuration
+            dataloader = DataLoader(
+                sc_dataset,
+                batch_size=None,
+                num_workers=num_workers,
+                prefetch_factor=(
+                    17 if num_workers > 0 else None
+                ),  # Only use prefetch_factor when num_workers > 0
+            )
+
+            # Warm up
+            warmup_batches = 3
+            for i, _batch in enumerate(dataloader):
+                if i >= warmup_batches:
+                    break
+
+            # Benchmark with peak memory tracking
+            desc = f"num_workers={num_workers}"
+
+            total_cells, batch_count, elapsed_time, peak_memory = (
+                self.benchmark_with_memory_tracking(
+                    dataloader, self.measurement_duration, desc
+                )
+            )
+
+            # Clean up the dataloader to stop background processing
+            del dataloader
+            gc.collect()
+
+            # Calculate metrics
+            throughput_cells_per_sec = total_cells / elapsed_time
+
+            return MultiprocessingBenchmarkResult(
+                num_workers=num_workers,
+                throughput_cells_per_sec=throughput_cells_per_sec,
+                memory_usage_gb=peak_memory,
+                measurement_time=elapsed_time,
+                total_cells=total_cells,
+                batches_processed=batch_count,
+            )
+
+        except Exception as e:
+            self.console.print(
+                f"[red]Error benchmarking num_workers={num_workers}: {e}[/red]"
+            )
+            return None
+
+    def run_benchmarks(self) -> list[MultiprocessingBenchmarkResult]:
+        """Run benchmarks for all num_workers values."""
+
+        self.console.print(
+            Panel.fit(
+                "[bold green]scDataset Multiprocessing Benchmark[/bold green]\n"
+                f"Testing performance scaling with num_workers (block_size={self.block_size}, fetch_factor={self.fetch_factor})",
+                border_style="green",
+            )
+        )
+
+        results = []
+
+        # Test all num_workers values
+        for num_workers in self.num_workers_list:
+            self.console.print(f"\n[bold]Testing num_workers={num_workers}[/bold]")
+
+            result = self.benchmark_scdataset_multiprocessing(num_workers)
+            if result:
+                results.append(result)
+                self.console.print(
+                    f"  Result: {result.throughput_cells_per_sec:.0f} cells/sec"
+                )
+
+        return results
+
+    def print_results(self, results: list[MultiprocessingBenchmarkResult]):
+        """Print benchmark results in formatted tables."""
+
+        if not results:
+            self.console.print("[red]No results to display[/red]")
+            return
+
+        # Create results table
+        self.console.print("\n[bold]scDataset Multiprocessing Results[/bold]")
+
+        table = Table(title="scDataset Multiprocessing Performance")
+        table.add_column("Num Workers", style="cyan")
+        table.add_column("Throughput (cells/sec)", style="green")
+        table.add_column("Memory (GB)", style="yellow")
+        table.add_column("Batches", style="blue")
+        table.add_column("Time (s)", style="yellow")
+
+        for result in results:
+            # Color code the throughput
+            throughput_text = f"{result.throughput_cells_per_sec:.0f}"
+            if result.throughput_cells_per_sec > 3000:
+                throughput_text = f"[green]{throughput_text}[/green]"
+            elif result.throughput_cells_per_sec > 2000:
+                throughput_text = f"[yellow]{throughput_text}[/yellow]"
+
+            table.add_row(
+                str(result.num_workers),
+                throughput_text,
+                f"{result.memory_usage_gb:.1f}",
+                str(result.batches_processed),
+                f"{result.measurement_time:.1f}",
+            )
+
+        self.console.print(table)
+
+        # Summary statistics
+        if results:
+            max_throughput = max(r.throughput_cells_per_sec for r in results)
+            best_config = next(
+                r for r in results if r.throughput_cells_per_sec == max_throughput
+            )
+
+            self.console.print("\n[bold]Summary:[/bold]")
+            self.console.print(f"Best performance: {max_throughput:.0f} cells/sec")
+            self.console.print(
+                f"Best configuration: num_workers={best_config.num_workers}"
+            )
+
+            # Calculate scaling factor
+            single_worker_result = next(
+                (r for r in results if r.num_workers == 0), None
+            )
+            if single_worker_result and best_config.num_workers > 0:
+                scaling_factor = (
+                    best_config.throughput_cells_per_sec
+                    / single_worker_result.throughput_cells_per_sec
+                )
+                self.console.print(
+                    f"Multiprocessing scaling factor: {scaling_factor:.1f}x"
+                )
+
+                if scaling_factor < 1.5:
+                    self.console.print(
+                        "[yellow]Note: Limited multiprocessing scaling observed - this may differ from paper results[/yellow]"
+                    )
+                else:
+                    self.console.print(
+                        "[green]Significant multiprocessing scaling observed[/green]"
+                    )
+
+
+def main():
+    """Run the scDataset multiprocessing benchmarks."""
+
+    # Use a smaller dataset for development
+    slaf_path = "../slaf-datasets/plate1_Tahoe100M.slaf"
+    h5ad_path = "../slaf-datasets/plate1_Tahoe100M.h5ad"
+
+    benchmark = scDatasetMultiprocessingBenchmark(slaf_path, h5ad_path)
+    results = benchmark.run_benchmarks()
+    benchmark.print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_scdataset_scaling.py
+++ b/benchmarks/benchmark_scdataset_scaling.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""
+scDataset Parameter Scaling Benchmark
+
+This benchmark tests scDataset performance scaling with different block_size and fetch_factor parameters.
+Based on scDataset paper Figure 2 which shows performance scaling with these parameters.
+"""
+
+import gc
+import time
+from dataclasses import dataclass
+
+import anndata as ad
+import psutil
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from tqdm import tqdm
+
+from slaf.core.slaf import SLAFArray
+
+
+# Define the fetch_transform callback for AnnData at module level
+def fetch_transform_adata(batch):
+    """Callback function to transform scDataset batches to AnnData format."""
+    return batch.to_adata()
+
+
+@dataclass
+class ScalingBenchmarkResult:
+    """Results from scDataset scaling benchmark."""
+
+    block_size: int
+    fetch_factor: int
+    throughput_cells_per_sec: float
+    memory_usage_gb: float
+    measurement_time: float
+    total_cells: int
+    batches_processed: int
+
+
+class scDatasetScalingBenchmark:
+    """Benchmark scDataset parameter scaling performance."""
+
+    def __init__(self, slaf_path: str, h5ad_path: str):
+        self.slaf_path = slaf_path
+        self.h5ad_path = h5ad_path
+        self.console = Console()
+
+        # Load SLAF array
+        self.console.print(f"Loading SLAF array from {slaf_path}...")
+        self.slaf_array = SLAFArray(slaf_path)
+
+        # Load AnnData object
+        self.console.print(f"Loading AnnData from {h5ad_path}...")
+        self.adata = ad.read_h5ad(h5ad_path, backed="r")
+        self.console.print(
+            f"Loaded {self.adata.n_obs:,} cells, {self.adata.n_vars:,} genes"
+        )
+
+        # Benchmark parameters
+        self.batch_size = 64
+        self.measurement_duration = 10  # seconds
+
+        # Parameter ranges to test
+        self.block_sizes = [1, 2, 4, 8, 16, 32, 64]
+        self.fetch_factors = [1, 2, 4, 8, 16, 32, 64]
+
+    def measure_memory_usage_gb(self) -> float:
+        """Get current memory usage in GB."""
+        process = psutil.Process()
+        return process.memory_info().rss / 1024 / 1024 / 1024
+
+    def track_peak_memory(self, duration_seconds: float) -> float:
+        """Track peak memory usage over a duration."""
+        import threading
+
+        peak_memory = 0.0
+        stop_tracking = threading.Event()
+
+        def memory_monitor():
+            nonlocal peak_memory
+            while not stop_tracking.is_set():
+                current_memory = self.measure_memory_usage_gb()
+                peak_memory = max(peak_memory, current_memory)
+                time.sleep(0.1)  # Check every 100ms
+
+        # Start memory monitoring in background thread
+        monitor_thread = threading.Thread(target=memory_monitor)
+        monitor_thread.daemon = True
+        monitor_thread.start()
+
+        # Wait for the specified duration
+        time.sleep(duration_seconds)
+
+        # Stop monitoring
+        stop_tracking.set()
+        monitor_thread.join(timeout=1.0)
+
+        return peak_memory
+
+    def benchmark_with_memory_tracking(
+        self, dataloader, measurement_duration: float, desc: str
+    ):
+        """Run benchmark with memory tracking in parallel and progress bar."""
+        import threading
+
+        peak_memory = 0.0
+        stop_tracking = threading.Event()
+
+        def memory_monitor():
+            nonlocal peak_memory
+            while not stop_tracking.is_set():
+                current_memory = self.measure_memory_usage_gb()
+                peak_memory = max(peak_memory, current_memory)
+                time.sleep(0.1)  # Check every 100ms
+
+        # Start memory monitoring in background thread
+        monitor_thread = threading.Thread(target=memory_monitor)
+        monitor_thread.daemon = True
+        monitor_thread.start()
+
+        # Run the actual benchmark with progress bar
+        start_time = time.time()
+        total_cells = 0
+        batch_count = 0
+
+        with tqdm(desc=desc, unit="batch") as pbar:
+            for _batch in dataloader:
+                batch_start = time.time()
+                batch_count += 1
+
+                # Use actual batch size from the data
+                if isinstance(_batch, dict):
+                    if "X" in _batch:
+                        actual_batch_size = _batch["X"].shape[0]
+                    elif "cell_ids" in _batch:
+                        actual_batch_size = len(_batch["cell_ids"])
+                    else:
+                        actual_batch_size = self.batch_size
+                else:
+                    actual_batch_size = self.batch_size
+                total_cells += actual_batch_size
+
+                # Force actual data loading
+                if hasattr(_batch, "X"):
+                    _ = _batch.X  # Force data loading
+                elif isinstance(_batch, dict) and "X" in _batch:
+                    _ = _batch["X"]  # Force data loading
+
+                batch_end = time.time()
+                _batch_time_ms = (batch_end - batch_start) * 1000
+
+                # Calculate current throughput
+                elapsed = time.time() - start_time
+                current_throughput = total_cells / elapsed if elapsed > 0 else 0
+
+                # Update progress bar
+                pbar.set_postfix(
+                    {
+                        "throughput": f"{current_throughput:.0f} cells/s",
+                        "memory": f"{peak_memory:.1f}GB",
+                    }
+                )
+                pbar.update(1)
+
+                # Stop after measurement duration
+                if elapsed >= measurement_duration:
+                    break
+
+        elapsed_time = time.time() - start_time
+
+        # Stop memory monitoring
+        stop_tracking.set()
+        monitor_thread.join(timeout=1.0)
+
+        return total_cells, batch_count, elapsed_time, peak_memory
+
+    def benchmark_scdataset_parameters(
+        self, block_size: int, fetch_factor: int
+    ) -> ScalingBenchmarkResult | None:
+        """Benchmark scDataset with specific block_size and fetch_factor parameters."""
+
+        try:
+            from anndata.experimental import AnnCollection
+            from scdataset import scDataset
+            from torch.utils.data import DataLoader
+        except ImportError:
+            self.console.print(
+                "[yellow]Warning: scDataset not available, skipping benchmark[/yellow]"
+            )
+            return None
+
+        try:
+            # Setup scDataset with current parameters
+            collection = AnnCollection([self.adata])
+
+            sc_dataset = scDataset(
+                data_collection=collection,
+                batch_size=self.batch_size,
+                block_size=block_size,
+                fetch_factor=fetch_factor,
+                fetch_transform=fetch_transform_adata,  # Use module-level callback
+            )
+
+            # Create DataLoader with single worker for parameter scaling test
+            dataloader = DataLoader(
+                sc_dataset,
+                batch_size=None,
+                num_workers=0,  # Single worker
+                prefetch_factor=None,  # No prefetch_factor for single worker
+            )
+
+            # Warm up
+            warmup_batches = 3
+            for i, _batch in enumerate(dataloader):
+                if i >= warmup_batches:
+                    break
+
+            # Benchmark with peak memory tracking
+            desc = f"block_size={block_size}, fetch_factor={fetch_factor}"
+
+            total_cells, batch_count, elapsed_time, peak_memory = (
+                self.benchmark_with_memory_tracking(
+                    dataloader, self.measurement_duration, desc
+                )
+            )
+
+            # Clean up the dataloader to stop background processing
+            del dataloader
+            gc.collect()
+
+            # Calculate metrics
+            throughput_cells_per_sec = total_cells / elapsed_time
+
+            return ScalingBenchmarkResult(
+                block_size=block_size,
+                fetch_factor=fetch_factor,
+                throughput_cells_per_sec=throughput_cells_per_sec,
+                memory_usage_gb=peak_memory,
+                measurement_time=elapsed_time,
+                total_cells=total_cells,
+                batches_processed=batch_count,
+            )
+
+        except Exception as e:
+            self.console.print(
+                f"[red]Error benchmarking block_size={block_size}, fetch_factor={fetch_factor}: {e}[/red]"
+            )
+            return None
+
+    def run_benchmarks(self) -> list[ScalingBenchmarkResult]:
+        """Run benchmarks for all parameter combinations."""
+
+        self.console.print(
+            Panel.fit(
+                "[bold green]scDataset Parameter Scaling Benchmark[/bold green]\n"
+                "Testing performance scaling with block_size and fetch_factor parameters",
+                border_style="green",
+            )
+        )
+
+        results = []
+
+        # Test all parameter combinations
+        for block_size in self.block_sizes:
+            for fetch_factor in self.fetch_factors:
+                self.console.print(
+                    f"\n[bold]Testing block_size={block_size}, fetch_factor={fetch_factor}[/bold]"
+                )
+
+                result = self.benchmark_scdataset_parameters(block_size, fetch_factor)
+                if result:
+                    results.append(result)
+                    self.console.print(
+                        f"  Result: {result.throughput_cells_per_sec:.0f} cells/sec"
+                    )
+
+        return results
+
+    def print_results(self, results: list[ScalingBenchmarkResult]):
+        """Print benchmark results in formatted tables."""
+
+        if not results:
+            self.console.print("[red]No results to display[/red]")
+            return
+
+        # Create results table
+        self.console.print("\n[bold]scDataset Parameter Scaling Results[/bold]")
+
+        table = Table(title="scDataset Parameter Scaling Performance")
+        table.add_column("Block Size", style="cyan")
+        table.add_column("Fetch Factor", style="cyan")
+        table.add_column("Throughput (cells/sec)", style="green")
+        table.add_column("Memory (GB)", style="yellow")
+        table.add_column("Batches", style="blue")
+        table.add_column("Time (s)", style="yellow")
+
+        for result in results:
+            # Color code the throughput
+            throughput_text = f"{result.throughput_cells_per_sec:.0f}"
+            if result.throughput_cells_per_sec > 3000:
+                throughput_text = f"[green]{throughput_text}[/green]"
+            elif result.throughput_cells_per_sec > 2000:
+                throughput_text = f"[yellow]{throughput_text}[/yellow]"
+
+            table.add_row(
+                str(result.block_size),
+                str(result.fetch_factor),
+                throughput_text,
+                f"{result.memory_usage_gb:.1f}",
+                str(result.batches_processed),
+                f"{result.measurement_time:.1f}",
+            )
+
+        self.console.print(table)
+
+        # Summary statistics
+        if results:
+            max_throughput = max(r.throughput_cells_per_sec for r in results)
+            best_config = next(
+                r for r in results if r.throughput_cells_per_sec == max_throughput
+            )
+
+            self.console.print("\n[bold]Summary:[/bold]")
+            self.console.print(f"Best performance: {max_throughput:.0f} cells/sec")
+            self.console.print(
+                f"Best configuration: block_size={best_config.block_size}, fetch_factor={best_config.fetch_factor}"
+            )
+
+            # Check if there's any scaling
+            min_throughput = min(r.throughput_cells_per_sec for r in results)
+            scaling_factor = (
+                max_throughput / min_throughput if min_throughput > 0 else 1
+            )
+            self.console.print(f"Scaling factor: {scaling_factor:.1f}x")
+
+            if scaling_factor < 1.5:
+                self.console.print(
+                    "[yellow]Note: Limited scaling observed - this may differ from paper results[/yellow]"
+                )
+            else:
+                self.console.print("[green]Significant scaling observed[/green]")
+
+
+def main():
+    """Run the scDataset parameter scaling benchmarks."""
+
+    # Use a smaller dataset for development
+    slaf_path = "../slaf-datasets/plate1_Tahoe100M.slaf"
+    h5ad_path = "../slaf-datasets/plate1_Tahoe100M.h5ad"
+
+    benchmark = scDatasetScalingBenchmark(slaf_path, h5ad_path)
+    results = benchmark.run_benchmarks()
+    benchmark.print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/benchmarks/scdataset_benchmarks.md
+++ b/docs/benchmarks/scdataset_benchmarks.md
@@ -1,0 +1,170 @@
+# scDataset Benchmarks
+
+This document reports comprehensive benchmark results for scDataset, a high-performance dataloader for single-cell data. These benchmarks were conducted using the Tahoe-100M dataset to evaluate scDataset's performance characteristics and scaling behavior.
+
+## **Dataset and Hardware**
+
+### **Dataset: Tahoe-100M**
+
+- **Cells**: 5,481,420 cells
+- **Genes**: 62,710 genes
+- **Format**: h5ad (backed mode)
+- **Batch Size**: 64 cells per batch
+
+### **Hardware Configuration**
+
+- **Machine**: Apple MacBook Pro with M1 Max
+- **Memory**: 32 GB RAM
+- **Storage**: 1 TB NVMe SSD
+- **OS**: macOS 13.6.1
+
+## **Parameter Scaling Benchmarks**
+
+### **Methodology**
+
+We tested scDataset performance across different combinations of `block_size` and `fetch_factor` parameters, which are key to scDataset's performance according to their paper. All tests used:
+
+- **Single worker** (`num_workers=0`) to isolate parameter effects
+- **10-second measurement duration**
+- **Module-level callback** to avoid pickling issues
+- **Backed AnnData** to match real-world usage
+
+### **Results Summary**
+
+| Parameter Range                          | Best Performance     | Best Configuration              | Scaling Factor |
+| ---------------------------------------- | -------------------- | ------------------------------- | -------------- |
+| `block_size`: [1, 2, 4, 8, 16, 32, 64]   | **10,976 cells/sec** | `block_size=8, fetch_factor=64` | **23.1x**      |
+| `fetch_factor`: [1, 2, 4, 8, 16, 32, 64] |                      |                                 |                |
+
+### **Key Findings**
+
+#### **1. Strong Scaling with fetch_factor**
+
+- **Minimal fetch_factor (1)**: ~500 cells/sec
+- **Optimal fetch_factor (64)**: ~10,000+ cells/sec
+- **Scaling factor**: 20x+ improvement with higher fetch_factor
+
+#### **2. Moderate Scaling with block_size**
+
+- **Small block_size (1-4)**: Good performance with high fetch_factor
+- **Medium block_size (8-16)**: Optimal performance
+- **Large block_size (32-64)**: Slightly reduced performance
+
+#### **3. Memory Usage Patterns**
+
+- **Low fetch_factor**: Higher memory usage (5GB+)
+- **High fetch_factor**: Lower memory usage (1-2GB)
+- **Optimal configuration**: ~2.7GB peak memory
+
+### **Detailed Results Table**
+
+| Block Size | Fetch Factor | Throughput (cells/sec) | Memory (GB) |
+| ---------- | ------------ | ---------------------- | ----------- |
+| 1          | 1            | 474                    | 5.0         |
+| 1          | 64           | 10,093                 | 2.4         |
+| 4          | 16           | 5,103                  | 1.6         |
+| 8          | 64           | **10,976**             | 2.7         |
+| 16         | 64           | 10,484                 | 2.4         |
+| 32         | 64           | 9,382                  | 2.4         |
+| 64         | 64           | 10,159                 | 2.7         |
+
+!!! success "Parameter Optimization"
+The optimal configuration for scDataset on our hardware is `block_size=8, fetch_factor=64`, achieving **10,976 cells/sec** with reasonable memory usage.
+
+## **Multiprocessing Benchmarks**
+
+### **Methodology**
+
+We tested scDataset's multiprocessing capabilities using the optimal parameters (`block_size=4, fetch_factor=16`) and varying `num_workers` values.
+
+### **Results**
+
+| Num Workers | Throughput (cells/sec) | Status            |
+| ----------- | ---------------------- | ----------------- |
+| 0           | 5,363                  | ✅ Success        |
+| 1           | N/A                    | ❌ Pickling Error |
+| 2           | N/A                    | ❌ Pickling Error |
+| 4           | N/A                    | ❌ Pickling Error |
+| 8           | N/A                    | ❌ Pickling Error |
+
+### **Key Findings**
+
+#### **1. Multiprocessing Limitations**
+
+- **Single worker only**: scDataset works reliably with `num_workers=0`
+- **Pickling errors**: All multiprocessing attempts failed with "h5py objects cannot be pickled"
+- **Callback issues**: Module-level callbacks didn't resolve the pickling problem
+
+#### **2. Performance Comparison**
+
+- **Single worker**: 5,363 cells/sec with optimal parameters
+- **No multiprocessing scaling**: Unable to test due to pickling limitations
+
+!!! warning "Multiprocessing Limitation"
+scDataset's multiprocessing capabilities are limited by pickling issues with h5py-backed AnnData objects. This prevents the scaling benefits reported in their paper.
+
+## **Comparison with Paper Results**
+
+### **Reported vs Observed Performance**
+
+| Metric                | Paper Claim      | Our Results      | Difference      |
+| --------------------- | ---------------- | ---------------- | --------------- |
+| **Best throughput**   | ~2,000 cells/sec | 10,976 cells/sec | **5.5x higher** |
+| **Parameter scaling** | Significant      | 23.1x scaling    | **Matches**     |
+| **Multiprocessing**   | 12 workers       | 0 workers only   | **Limited**     |
+
+### **Possible Explanations**
+
+1. **Hardware differences**: Our M1 Max may be faster than the paper's hardware
+2. **Dataset differences**: Different datasets may have different characteristics
+3. **Implementation differences**: Different scDataset versions or configurations
+4. **Measurement methodology**: Different benchmark setups
+
+!!! info "Performance Validation"
+Our results show that scDataset can achieve excellent performance with proper parameter tuning, even exceeding the paper's reported numbers on modern hardware.
+
+## **Technical Challenges**
+
+### **1. Pickling Issues**
+
+- **Problem**: h5py objects cannot be pickled for multiprocessing
+- **Impact**: Prevents multiprocessing scaling
+- **Workaround**: Use single worker with optimized parameters
+
+### **2. Parameter Sensitivity**
+
+- **Problem**: Performance varies dramatically with parameters
+- **Impact**: Requires careful tuning for optimal performance
+- **Solution**: Systematic parameter sweeps
+
+### **3. Memory Usage**
+
+- **Problem**: High memory usage with low fetch_factor
+- **Impact**: May limit batch sizes on memory-constrained systems
+- **Solution**: Use higher fetch_factor values
+
+## **Recommendations**
+
+### **For scDataset Users**
+
+1. **Parameter Tuning**: Always test different `block_size` and `fetch_factor` combinations
+2. **Single Worker**: Use `num_workers=0` to avoid pickling issues
+3. **Memory Monitoring**: Monitor memory usage, especially with low fetch_factor
+4. **Hardware Testing**: Test on your specific hardware for optimal parameters
+
+### **For Developers**
+
+1. **Pickling Fix**: Address h5py pickling issues for multiprocessing support
+2. **Parameter Documentation**: Provide clearer guidance on parameter selection
+3. **Memory Optimization**: Reduce memory usage with low fetch_factor values
+4. **Benchmark Suite**: Include comprehensive benchmark tools
+
+## **Conclusion**
+
+scDataset demonstrates excellent performance potential with proper parameter tuning, achieving **10,976 cells/sec** in our benchmarks. However, multiprocessing limitations prevent the scaling benefits reported in their paper. The strong parameter scaling validates their design approach, but the pickling issues need to be addressed for broader adoption.
+
+The benchmark results show that scDataset can be a viable high-performance dataloader for single-cell data, but requires careful configuration and has limitations for multiprocessing scenarios.
+
+---
+
+_These benchmarks were conducted using scDataset with backed AnnData objects on the Tahoe-100M dataset. Results may vary with different datasets, hardware configurations, or scDataset versions._


### PR DESCRIPTION
Improved benchmarks for scdataset vs slaf dataloader with suggestions from scdataset developers. 

Highlights
- impressive scale up with block_size and fetch_factor parameter tuning after adding callback
- multiprocessing still does not work, citing pickling issue. it could be something to do with torch versions.
- we're not yet ready to benchmark on full Tahoe-100M: will need more storage and compute for conversion, but will get there eventually
- no change yet to warm up and measurement time in the code but no material change to key numbers when we tested it with longer warmup and measurement times (not reported here)
 
See: https://github.com/Kidara/scDataset/issues/1 for detailed discussions