### PR TITLE
Fix scGPT tokenizer to canonical dual stream

### DIFF
--- a/slaf/distributed/dataloader.py
+++ b/slaf/distributed/dataloader.py
@@ -379,12 +379,17 @@ class DistributedDataLoader:
                     # Type: ignore because we know these will be filled with tensors
                     input_ids_list: list[Any] = [None] * batch_size
                     attention_mask_list: list[Any] = [None] * batch_size
+                    values_list: list[Any] | None = (
+                        [None] * batch_size if "values" in samples[0] else None
+                    )
                     cell_ids_list = [0] * batch_size
 
                     # Single pass: extract all data
                     for i, s in enumerate(samples):
                         input_ids_list[i] = s["input_ids"]
                         attention_mask_list[i] = s["attention_mask"]
+                        if values_list is not None:
+                            values_list[i] = s.get("values")
                         cell_ids_list[i] = s.get("group_key", 0)
 
                     # Stack tensors in single operations (very fast)
@@ -392,13 +397,26 @@ class DistributedDataLoader:
                     input_ids = torch.stack(input_ids_list)  # type: ignore[arg-type]
                     attention_mask = torch.stack(attention_mask_list)  # type: ignore[arg-type]
                     cell_ids = torch.tensor(cell_ids_list, dtype=torch.long)
+                    if values_list is not None:
+                        values = torch.stack(values_list)  # type: ignore[arg-type]
+                        if values.shape != input_ids.shape:
+                            raise ValueError(
+                                "Distributed scGPT dual-stream contract violated: values and "
+                                f"input_ids shapes differ ({tuple(values.shape)} vs {tuple(input_ids.shape)})"
+                            )
+                        if values.shape != attention_mask.shape:
+                            raise ValueError(
+                                "Distributed scGPT dual-stream contract violated: values and "
+                                f"attention_mask shapes differ ({tuple(values.shape)} vs {tuple(attention_mask.shape)})"
+                            )
 
                     # Extract other keys only if they exist (use Polars for efficiency)
                     first_sample = samples[0]
                     extra_keys = [
                         key
                         for key in first_sample.keys()
-                        if key not in ["input_ids", "attention_mask", "group_key"]
+                        if key
+                        not in ["input_ids", "attention_mask", "group_key", "values"]
                     ]
                     if extra_keys:
                         # Use Polars DataFrame for efficient column extraction
@@ -411,12 +429,15 @@ class DistributedDataLoader:
                     else:
                         extra_data = {}
 
-                    yield {
+                    batch = {
                         "input_ids": input_ids,
                         "attention_mask": attention_mask,
                         "cell_ids": cell_ids,  # Matches SLAFDataLoader format
                         **extra_data,
                     }
+                    if values_list is not None:
+                        batch["values"] = values
+                    yield batch
                 except ImportError:
                     # PyTorch not available - fall back to lists
                     yield {

--- a/slaf/distributed/worker.py
+++ b/slaf/distributed/worker.py
@@ -122,9 +122,14 @@ def prefetch_worker(
             def tokenize_grouped(
                 grouped_df: pl.DataFrame, schema: DataSchema
             ) -> dict[str, Any]:
-                """Tokenize grouped DataFrame with gene sequences."""
+                """Tokenize grouped DataFrame with gene/value sequences.
+
+                For scGPT tokenizers, this enforces the dual-stream contract:
+                tokenized output must include aligned ``input_ids`` and ``values``.
+                """
                 # Extract gene sequences and expression sequences
                 gene_sequences = grouped_df[schema.item_list_key].to_list()
+                is_scgpt_tokenizer = hasattr(tokenizer_instance, "n_expression_bins")
 
                 # Check if we have expression sequences (for scGPT)
                 if (
@@ -132,19 +137,37 @@ def prefetch_worker(
                     and schema.value_list_key in grouped_df.columns
                 ):
                     expr_sequences = grouped_df[schema.value_list_key].to_list()
-                    input_ids, attention_mask = tokenizer_instance.tokenize(
+                    input_ids, attention_mask, values = tokenizer_instance.tokenize(
                         gene_sequences, expr_sequences
                     )
                 else:
-                    input_ids, attention_mask = tokenizer_instance.tokenize(
+                    input_ids, attention_mask, values = tokenizer_instance.tokenize(
                         gene_sequences
                     )
 
+                if is_scgpt_tokenizer:
+                    if (
+                        not schema.value_list_key
+                        or schema.value_list_key not in grouped_df.columns
+                    ):
+                        raise ValueError(
+                            "scGPT distributed tokenization requires expression/value sequences; "
+                            f"missing grouped column '{schema.value_list_key}'."
+                        )
+                    if values is None:
+                        raise ValueError(
+                            "scGPT distributed tokenization requires dual-stream output; "
+                            "tokenizer returned values=None."
+                        )
+
                 # Return as dict (format expected by processor)
-                return {
+                result = {
                     "input_ids": input_ids,
                     "attention_mask": attention_mask,
                 }
+                if values is not None:
+                    result["values"] = values
+                return result
 
             tokenizer_fn = tokenize_grouped
 

--- a/slaf/ml/datasets.py
+++ b/slaf/ml/datasets.py
@@ -277,6 +277,7 @@ class TokenizedPrefetchBatch:
     input_ids: torch.Tensor  # Tokenized sequences
     attention_mask: torch.Tensor  # Attention masks
     cell_integer_ids: list[int]  # Corresponding cell integer IDs
+    values: torch.Tensor | None = None  # scGPT aligned expression/value stream
     partial_cell_data: dict | None = (
         None  # Store partial cell data for boundary handling
     )
@@ -1041,7 +1042,7 @@ class PrefetchBatchProcessor:
                     if self.tokenizer is None:
                         raise RuntimeError("Tokenizer is required for tokenized mode")
 
-                    input_ids, attention_mask = self.tokenizer.tokenize(
+                    input_ids, attention_mask, values = self.tokenizer.tokenize(
                         gene_sequences=grouped["gene_sequence"].to_list(),
                         expr_sequences=(
                             grouped["expr_sequence"].to_list()
@@ -1083,6 +1084,7 @@ class PrefetchBatchProcessor:
                         batch_id=self.batch_id - 1,
                         input_ids=input_ids,
                         attention_mask=attention_mask,
+                        values=values,
                         cell_integer_ids=cell_ids_ordered,
                         partial_cell_data=self.partial_cell_data.copy(),
                         tokenize_time=tokenize_time,
@@ -1823,6 +1825,19 @@ class SLAFIterableDataset(IterableDataset):
                 # Tokenized mode: process pre-tokenized sequences
                 input_ids = data.input_ids
                 attention_mask = data.attention_mask
+                values = data.values
+
+                if values is not None:
+                    if values.shape != input_ids.shape:
+                        raise ValueError(
+                            "scGPT dual-stream contract violated: values and input_ids must "
+                            f"have identical shapes, got {tuple(values.shape)} vs {tuple(input_ids.shape)}"
+                        )
+                    if values.shape != attention_mask.shape:
+                        raise ValueError(
+                            "scGPT dual-stream contract violated: values and attention_mask must "
+                            f"have identical shapes, got {tuple(values.shape)} vs {tuple(attention_mask.shape)}"
+                        )
 
                 # Process all cells in this data chunk
                 for batch_start in range(0, num_cells, self.batch_size):
@@ -1831,6 +1846,9 @@ class SLAFIterableDataset(IterableDataset):
                     # Extract batch data
                     batch_input_ids = input_ids[batch_start:batch_end]
                     batch_attention_mask = attention_mask[batch_start:batch_end]
+                    batch_values = (
+                        values[batch_start:batch_end] if values is not None else None
+                    )
                     batch_cell_ids = cell_integer_ids[batch_start:batch_end]
 
                     # Convert cell IDs to tensor (pre-allocated)
@@ -1877,6 +1895,8 @@ class SLAFIterableDataset(IterableDataset):
                         "attention_mask": batch_attention_mask,
                         "cell_ids": cell_ids_tensor,
                     }
+                    if batch_values is not None:
+                        batch_dict["values"] = batch_values
 
                     # Add epoch information if using multiple epochs
                     if self.n_epochs > 1:

--- a/slaf/ml/distributed.py
+++ b/slaf/ml/distributed.py
@@ -360,7 +360,8 @@ class DistributedSLAFDataLoader:
             value_key="value",  # Values are expression
             group_key_out="cell_integer_id",  # Output keeps same group key
             item_list_key="gene_sequence",  # Aggregated gene list
-            value_list_key="expr_sequence",  # Aggregated expression list (for scGPT)
+            # Aggregated expression/value list used by scGPT dual-stream tokenization
+            value_list_key="expr_sequence",
         )
 
         processor_config = {

--- a/slaf/ml/tokenizers.py
+++ b/slaf/ml/tokenizers.py
@@ -451,32 +451,32 @@ class ScGPTTokenizer(SLAFTokenizer):
                 gene_ids = np.full(
                     sequence_length, self.special_tokens["PAD"], dtype=np.int64
                 )
-                values = np.full(
+                value_tokens = np.full(
                     sequence_length, self.special_tokens["PAD"], dtype=np.int64
                 )
                 gene_ids[0] = self.special_tokens["CLS"]
                 gene_ids[1 : 1 + n_pairs] = gene_tokens
                 gene_ids[1 + n_pairs] = self.special_tokens["SEP"]
-                values[1 : 1 + n_pairs] = expr_tokens
+                value_tokens[1 : 1 + n_pairs] = expr_tokens
             else:
                 gene_ids = np.array(
                     [self.special_tokens["CLS"], self.special_tokens["SEP"]],
                     dtype=np.int64,
                 )
-                values = np.array(
+                value_tokens = np.array(
                     [self.special_tokens["PAD"], self.special_tokens["PAD"]],
                     dtype=np.int64,
                 )
 
             length = min(len(gene_ids), max_sequence_length)
             gene_token_array[i, :length] = gene_ids[:length]
-            value_array[i, :length] = values[:length]
+            value_array[i, :length] = value_tokens[:length]
 
         input_ids = torch.from_numpy(gene_token_array)
-        values = torch.from_numpy(value_array)
+        values_tensor = torch.from_numpy(value_array)
         attention_mask = input_ids != self.special_tokens["PAD"]
 
-        return input_ids, attention_mask, values
+        return input_ids, attention_mask, values_tensor
 
     def get_vocab_info(self) -> dict[str, Any]:
         """

--- a/slaf/ml/tokenizers.py
+++ b/slaf/ml/tokenizers.py
@@ -263,7 +263,7 @@ class SLAFTokenizer(ABC):
         self,
         gene_sequences: list[list[int] | list[tuple[int, float]]],
         expr_sequences: list[list[float]] | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         """
         Tokenize gene expression sequences into model-ready tensors.
 
@@ -376,7 +376,7 @@ class ScGPTTokenizer(SLAFTokenizer):
         self,
         gene_sequences: list[list[int] | list[tuple[int, float]]],
         expr_sequences: list[list[float]] | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         """
         Tokenize gene expression sequences into model-ready tensors.
 
@@ -407,95 +407,76 @@ class ScGPTTokenizer(SLAFTokenizer):
         if not gene_sequences:
             raise ValueError("Gene sequences cannot be empty")
 
-        # For scGPT: CLS + (gene,expr)*n + SEP = 2*n + 2
-        max_sequence_length = 2 * self.max_genes + 2  # Total sequence length
-
-        # For scGPT, gene_sequences now contains struct pairs [(gene, expr), ...]
-        # so we don't need separate expr_sequences validation
+        # Canonical scGPT contract: dual stream, aligned positions.
+        # gene_ids: [CLS] gene_1 ... gene_n [SEP] [PAD]...
+        # values:   [PAD] expr_1 ... expr_n [PAD] [PAD]...
+        max_sequence_length = self.max_genes + 2
 
         batch_size = len(gene_sequences)
 
         # Use fast numpy-based approach (same as original test)
         import numpy as np
 
-        # For scGPT: use max_sequence_length (2*max_genes+2)
-        array_width = max_sequence_length
-
-        token_array = np.full(
-            (batch_size, array_width), self.special_tokens["PAD"], dtype=np.int64
+        gene_token_array = np.full(
+            (batch_size, max_sequence_length),
+            self.special_tokens["PAD"],
+            dtype=np.int64,
+        )
+        value_array = np.full(
+            (batch_size, max_sequence_length),
+            self.special_tokens["PAD"],
+            dtype=np.int64,
         )
 
-        # scGPT format: [CLS] gene1 expr1 gene2 expr2 ... [SEP]
-        for i, (gene_sequence, expr_sequence) in enumerate(
-            zip(gene_sequences, expr_sequences or [], strict=False)
-        ):
-            # For scGPT, we now use separate gene_sequence and expr_sequence columns
-            if gene_sequence and len(gene_sequence) > 0:
-                # Fast path: separate gene_sequence and expr_sequence columns
-                genes = gene_sequence
-                exprs = expr_sequence if expr_sequence else []
+        for i, gene_sequence in enumerate(gene_sequences):
+            expr_sequence = expr_sequences[i] if expr_sequences is not None else []
+            genes = list(gene_sequence) if gene_sequence else []
+            exprs = list(expr_sequence) if expr_sequence else []
 
-                # Vectorized operations - use simple +4 for performance
-                gene_tokens = np.array(genes, dtype=np.int64) + 4
+            n_pairs = min(len(genes), len(exprs), self.max_genes)
 
-                # Handle expression tokens - don't bin if already binned by window function
-                if len(exprs) > 0 and isinstance(exprs[0], int | np.integer):
-                    # Already binned by window function - just convert to tokens
-                    expr_tokens = np.array(exprs, dtype=np.int64) + self.expr_bin_start
+            if n_pairs > 0:
+                gene_tokens = np.array(genes[:n_pairs], dtype=np.int64) + 4
+
+                if isinstance(exprs[0], int | np.integer):
+                    expr_tokens = (
+                        np.array(exprs[:n_pairs], dtype=np.int64) + self.expr_bin_start
+                    )
                 else:
-                    # Raw values - need to bin them
                     expr_tokens = self._expression_to_bin_vectorized(
-                        np.array(exprs, dtype=np.float32)
+                        np.array(exprs[:n_pairs], dtype=np.float32)
                     )
 
-                # Vectorized interleaving (much faster than Python loop)
-                if len(gene_tokens) > 0:
-                    # Pre-allocate full sequence: CLS + (gene,expr)*n + SEP
-                    sequence_length = 1 + 2 * len(gene_tokens) + 1
-                    tokens = np.full(
-                        sequence_length, self.special_tokens["PAD"], dtype=np.int64
-                    )
-
-                    # Set CLS token
-                    tokens[0] = self.special_tokens["CLS"]
-
-                    # Vectorized interleaving
-                    tokens[1::2][: len(gene_tokens)] = gene_tokens  # type: ignore[assignment]
-                    tokens[2::2][: len(expr_tokens)] = expr_tokens  # type: ignore[assignment]
-
-                    tokens[1 + 2 * len(gene_tokens)] = self.special_tokens["SEP"]
-                else:
-                    # Empty sequence case
-                    tokens = np.array(
-                        [self.special_tokens["CLS"], self.special_tokens["SEP"]],
-                        dtype=np.int64,
-                    )  # type: ignore[assignment]
+                sequence_length = n_pairs + 2
+                gene_ids = np.full(
+                    sequence_length, self.special_tokens["PAD"], dtype=np.int64
+                )
+                values = np.full(
+                    sequence_length, self.special_tokens["PAD"], dtype=np.int64
+                )
+                gene_ids[0] = self.special_tokens["CLS"]
+                gene_ids[1 : 1 + n_pairs] = gene_tokens
+                gene_ids[1 + n_pairs] = self.special_tokens["SEP"]
+                values[1 : 1 + n_pairs] = expr_tokens
             else:
-                # Empty sequence case
-                tokens = np.array(
+                gene_ids = np.array(
                     [self.special_tokens["CLS"], self.special_tokens["SEP"]],
                     dtype=np.int64,
-                )  # type: ignore[assignment]
-
-            target_length = max_sequence_length
-
-            tokens = tokens[:target_length]  # type: ignore[assignment]
-            if len(tokens) < target_length:
-                padding = np.full(
-                    target_length - len(tokens),
-                    self.special_tokens["PAD"],
+                )
+                values = np.array(
+                    [self.special_tokens["PAD"], self.special_tokens["PAD"]],
                     dtype=np.int64,
                 )
-                tokens = np.concatenate([tokens, padding])  # type: ignore[assignment]
 
-            # Fill array
-            token_array[i, :] = tokens  # type: ignore[assignment]
+            length = min(len(gene_ids), max_sequence_length)
+            gene_token_array[i, :length] = gene_ids[:length]
+            value_array[i, :length] = values[:length]
 
-        # Convert to tensors in one operation
-        input_ids = torch.from_numpy(token_array)
+        input_ids = torch.from_numpy(gene_token_array)
+        values = torch.from_numpy(value_array)
         attention_mask = input_ids != self.special_tokens["PAD"]
 
-        return input_ids, attention_mask
+        return input_ids, attention_mask, values
 
     def get_vocab_info(self) -> dict[str, Any]:
         """
@@ -655,7 +636,7 @@ class GeneformerTokenizer(SLAFTokenizer):
         self,
         gene_sequences: list[list[int] | list[tuple[int, float]]],
         expr_sequences: list[list[float]] | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         """
         Tokenize gene expression sequences into model-ready tensors.
 
@@ -738,7 +719,7 @@ class GeneformerTokenizer(SLAFTokenizer):
         input_ids = torch.from_numpy(token_array)
         attention_mask = input_ids != self.special_tokens["PAD"]
 
-        return input_ids, attention_mask
+        return input_ids, attention_mask, None
 
     def decode_tokens(self, tokens: list[int]) -> dict[str, Any]:
         """

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -65,7 +65,7 @@ class TestSLAFDataLoader:
             # Check batch structure
             assert "input_ids" in batch
             assert "attention_mask" in batch
-            assert "values" in batch
+            assert "values" not in batch
             assert "cell_ids" in batch
 
             # Check tensor shapes

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -65,6 +65,7 @@ class TestSLAFDataLoader:
             # Check batch structure
             assert "input_ids" in batch
             assert "attention_mask" in batch
+            assert "values" in batch
             assert "cell_ids" in batch
 
             # Check tensor shapes
@@ -107,11 +108,13 @@ class TestSLAFDataLoader:
             # Check tensor shapes
             input_ids = batch["input_ids"]
             attention_mask = batch["attention_mask"]
+            values = batch["values"]
             cell_ids = batch["cell_ids"]
 
             assert input_ids.shape[0] == attention_mask.shape[0]
             assert input_ids.shape[0] == cell_ids.shape[0]
-            assert input_ids.shape[1] == 22  # scGPT: 2 * max_genes + 2
+            assert input_ids.shape[1] == 12  # scGPT dual stream: max_genes + 2
+            assert values.shape == input_ids.shape
 
             # Check data types
             assert input_ids.dtype == torch.long

--- a/tests/test_distributed_dataloader.py
+++ b/tests/test_distributed_dataloader.py
@@ -117,6 +117,55 @@ class TestDistributedDataLoader:
             # Should be tensors
             assert hasattr(batches[0]["input_ids"], "shape")
 
+    def test_dataloader_return_tensors_true_with_values(self):
+        """Test scGPT-style values passthrough in tensor mode."""
+        try:
+            import torch
+        except ImportError:
+            pytest.skip("PyTorch not available")
+
+        samples = [
+            {
+                "input_ids": torch.tensor([1, 11, 2, 0]),
+                "attention_mask": torch.tensor([1, 1, 1, 0], dtype=torch.bool),
+                "values": torch.tensor([0, 1005, 0, 0]),
+                "group_key": i,
+            }
+            for i in range(4)
+        ]
+        queue = MockQueue(samples)
+        dataloader = DistributedDataLoader(
+            queue, batch_size=2, prefetch_factor=0, return_tensors=True
+        )
+
+        batches = list(dataloader)
+        assert len(batches) > 0
+        assert "values" in batches[0]
+        assert batches[0]["values"].shape == batches[0]["input_ids"].shape
+
+    def test_dataloader_values_shape_mismatch_raises(self):
+        """Mismatched values/input shapes should fail fast."""
+        try:
+            import torch
+        except ImportError:
+            pytest.skip("PyTorch not available")
+
+        samples = [
+            {
+                "input_ids": torch.tensor([1, 11, 2, 0]),
+                "attention_mask": torch.tensor([1, 1, 1, 0], dtype=torch.bool),
+                "values": torch.tensor([0, 1005, 0]),  # one shorter
+                "group_key": 0,
+            }
+        ]
+        queue = MockQueue(samples)
+        dataloader = DistributedDataLoader(
+            queue, batch_size=1, prefetch_factor=0, return_tensors=True
+        )
+
+        with pytest.raises(ValueError, match="dual-stream contract violated"):
+            list(dataloader)
+
     def test_dataloader_return_tensors_false(self):
         """Test return_tensors=False (Python lists)."""
         samples = [

--- a/tests/test_pytorch_datasets.py
+++ b/tests/test_pytorch_datasets.py
@@ -350,24 +350,47 @@ class TestSLAFIterableDataset:
             # Check batch structure
             assert "input_ids" in batch
             assert "attention_mask" in batch
+            assert "values" in batch
             assert "cell_ids" in batch
 
             # Check tensor types
             assert isinstance(batch["input_ids"], torch.Tensor)
             assert isinstance(batch["attention_mask"], torch.Tensor)
+            assert isinstance(batch["values"], torch.Tensor)
             assert isinstance(batch["cell_ids"], torch.Tensor)
 
             # Check shapes
             batch_size = batch["input_ids"].shape[0]
             seq_length = batch["input_ids"].shape[1]
             assert batch_size <= 8
-            assert seq_length == 2050  # scGPT: 2*1024+2
+            assert seq_length == 1026  # scGPT dual stream: max_genes+2
+            assert batch["values"].shape == batch["input_ids"].shape
 
             batch_count += 1
             if batch_count >= 3:  # Test first 3 batches
                 break
 
         assert batch_count > 0
+
+    def test_scgpt_values_alignment_contract(self, tiny_slaf):
+        """scGPT batches must keep aligned dual streams."""
+        tokenizer = ScGPTTokenizer(tiny_slaf, max_genes=16)
+        dataset = SLAFIterableDataset(
+            slaf_array=tiny_slaf,
+            tokenizer=tokenizer,
+            batch_size=8,
+        )
+
+        batch = next(iter(dataset))
+        input_ids = batch["input_ids"]
+        values = batch["values"]
+
+        assert values.shape == input_ids.shape
+        cls_positions = input_ids == tokenizer.special_tokens["CLS"]
+        sep_positions = input_ids == tokenizer.special_tokens["SEP"]
+        pad_value = tokenizer.special_tokens["PAD"]
+        assert torch.all(values[cls_positions] == pad_value)
+        assert torch.all(values[sep_positions] == pad_value)
 
     def test_device_transfer(self, tiny_slaf):
         """Test device transfer functionality"""

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -64,7 +64,7 @@ class TestSLAFTokenizer:
 
         # Test gene sequence tokenization
         gene_sequences = [[0, 1, 2], [1, 2, 0]]
-        input_ids, attention_mask = tokenizer.tokenize(gene_sequences)
+        input_ids, attention_mask, values = tokenizer.tokenize(gene_sequences)
 
         # Check output shapes
         assert input_ids.shape == (2, 2048)  # Geneformer default
@@ -73,6 +73,7 @@ class TestSLAFTokenizer:
         # Check that tokens are properly converted
         assert input_ids.dtype == torch.long
         assert attention_mask.dtype == torch.bool
+        assert values is None
 
         # Check Geneformer format: [CLS] gene1 gene2 gene3 ... [SEP]
         assert input_ids[0, 0] == 1  # CLS token
@@ -98,23 +99,34 @@ class TestSLAFTokenizer:
         gene_sequences = [[0, 1, 2], [1, 2, 0]]
         expr_sequences = [[0.5, 0.8, 0.2], [0.9, 0.1, 0.7]]
 
-        input_ids, attention_mask = tokenizer.tokenize(gene_sequences, expr_sequences)
+        input_ids, attention_mask, values = tokenizer.tokenize(
+            gene_sequences, expr_sequences
+        )
 
         # Check shapes
-        assert input_ids.shape == (2, 2050)  # scGPT: 2*1024+2
-        assert attention_mask.shape == (2, 2050)
+        assert input_ids.shape == (2, 1026)  # scGPT dual stream: max_genes+2
+        assert attention_mask.shape == (2, 1026)
+        assert values is not None
+        assert values.shape == (2, 1026)
 
         # Check that tokens are properly converted
         assert input_ids.dtype == torch.long
         assert attention_mask.dtype == torch.bool
 
-        # Check scGPT format: [CLS] gene1 expr1 gene2 expr2 ... [SEP]
+        # Check scGPT dual stream format: gene_ids has [CLS] gene1 ... [SEP]
         assert input_ids[0, 0] == 1  # CLS token
         assert input_ids[0, 1] >= 0  # First gene token (should be valid gene token)
-        # Expression tokens should be >= vocab_size (1000) for positive expressions
-        # or == 0 (PAD) for zero/negative expressions
-        assert input_ids[0, 2] >= 0  # Expression token (can be PAD or binned)
+        # Expression values live in separate aligned values tensor
+        assert values[0, 0] == 0  # CLS-aligned value position is PAD
+        assert values[0, 1] >= 0  # First expression token/bin
         assert attention_mask[0, 0]  # CLS token is valid
+
+        # Dual-stream alignment invariants (canonical scGPT contract)
+        assert values.shape == input_ids.shape
+        cls_positions = input_ids == tokenizer.special_tokens["CLS"]
+        sep_positions = input_ids == tokenizer.special_tokens["SEP"]
+        assert torch.all(values[cls_positions] == tokenizer.special_tokens["PAD"])
+        assert torch.all(values[sep_positions] == tokenizer.special_tokens["PAD"])
 
     def test_scgpt_tokenization_no_expression(self):
         """Test that scGPT tokenization works without expressions (empty sequences)."""
@@ -132,13 +144,14 @@ class TestSLAFTokenizer:
         # Test that it works with empty expression sequences
         gene_sequences = [[0, 1, 2], [1, 2, 0]]
 
-        input_ids, attention_mask = tokenizer.tokenize(
+        input_ids, attention_mask, values = tokenizer.tokenize(
             gene_sequences, expr_sequences=None
         )
 
         # Should work and produce valid output
-        assert input_ids.shape == (2, 2050)  # scGPT: 2*1024+2
-        assert attention_mask.shape == (2, 2050)
+        assert input_ids.shape == (2, 1026)  # scGPT dual stream: max_genes+2
+        assert attention_mask.shape == (2, 1026)
+        assert values is not None
 
     def test_tokenization_edge_cases(self):
         """Test edge cases for tokenization."""
@@ -159,13 +172,14 @@ class TestSLAFTokenizer:
 
         # Test sequences with empty gene lists
         gene_sequences = [[], [0, 1, 2]]
-        input_ids, attention_mask = tokenizer.tokenize(
+        input_ids, attention_mask, values = tokenizer.tokenize(
             gene_sequences, expr_sequences=None
         )
 
         # Should still work with empty gene lists
         assert input_ids.shape == (2, 2048)
         assert attention_mask.shape == (2, 2048)
+        assert values is None
 
     def test_expression_binning(self):
         """Test expression binning functionality."""
@@ -311,12 +325,13 @@ class TestSLAFTokenizerWithRealData:
 
         # Test tokenization with real gene sequences
         gene_sequences = [[0, 1, 2], [1, 2, 3]]
-        input_ids, attention_mask = tokenizer.tokenize(gene_sequences)
+        input_ids, attention_mask, values = tokenizer.tokenize(gene_sequences)
 
         assert input_ids.shape == (2, 2048)
         assert attention_mask.shape == (2, 2048)
         assert input_ids.dtype == torch.long
         assert attention_mask.dtype == torch.bool
+        assert values is None
 
     def test_scgpt_with_real_data(self, tiny_slaf):
         """Test scGPT tokenizer with real SLAF data."""
@@ -330,12 +345,15 @@ class TestSLAFTokenizerWithRealData:
         gene_sequences = [[0, 1, 2], [1, 2, 3]]
         expr_sequences = [[0.5, 0.8, 0.2], [0.9, 0.1, 0.7]]
 
-        input_ids, attention_mask = tokenizer.tokenize(gene_sequences, expr_sequences)
+        input_ids, attention_mask, values = tokenizer.tokenize(
+            gene_sequences, expr_sequences
+        )
 
-        assert input_ids.shape == (2, 2050)  # scGPT: 2*1024+2
-        assert attention_mask.shape == (2, 2050)
+        assert input_ids.shape == (2, 1026)  # scGPT dual stream: max_genes+2
+        assert attention_mask.shape == (2, 1026)
         assert input_ids.dtype == torch.long
         assert attention_mask.dtype == torch.bool
+        assert values is not None
 
     def test_gene_mapping_with_real_data(self, tiny_slaf):
         """Test gene ID mapping with real SLAF data."""


### PR DESCRIPTION
This PR aligns SLAF tokenization and distributed data delivery with canonical scGPT semantics by:

- switching scGPT tokenization to aligned input_ids + values streams,
- propagating values through local and distributed dataloaders,
- adding fail-fast shape/alignment checks (values vs input_ids/attention_mask),
- updating tests to lock in the dual-stream contract and special-token value invariants.

Background research that motivated the fix:

- Canonical repo: [bowang-lab/scGPT](https://github.com/bowang-lab/scGPT)
- Model encode path docs (src and values are separate inputs): [scgpt.model.model source docs](https://scgpt.readthedocs.io/en/latest/_modules/scgpt/model/model.html)
- Official finetune example using separate gene_ids and values: [examples/finetune_integration.py](https://github.com/bowang-lab/scGPT/blob/main/examples/finetune_integration.py)
- Cell embedding task showing separate gene/value tensors: [scgpt/tasks/cell_emb.py](https://github.com/bowang-lab/scGPT/blob/main/scgpt/tasks/cell_emb.py)
- Initial discussion thread: [DeepWiki thread](https://deepwiki.com/search/i-want-to-understand-the-exact_480f90a4-ad08-488a-923b-6357d6a66da5?mode=fast)

Thanks to @alam-shahul for calling this out