### PR TITLE
fix(pyproject): correct license to MIT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.5.2"
 description = "Sparse Lazy Array Format - MVP for single-cell data"
 authors = [{ name = "Pavan Ramkumar", email = "pavan.ramkumar@gmail.com" }]
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = "MIT"
+license-files = ["LICEN[CS]E.*"]
 requires-python = ">=3.10,<3.14"
 
 dependencies = [


### PR DESCRIPTION
This PR  declares the correct license (MIT) in `pyproject.toml`.
Fixes #52.