### PR TITLE
fix(converter): raise clear RuntimeError on non-POSIX output filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ uv add slafdb
 
 **Note**: Package managers don't automatically choose between `polars` and `polars-lts-cpu` - you may need to specify the correct version for your platform.
 
+**Output filesystem:** `.slaf` must be written to a local POSIX path (APFS, ext4). ExFAT/FAT32 drives are not supported ([lancedb#1231](https://github.com/lancedb/lancedb/issues/1231)).
+
 ### Optional Dependencies
 
 Add specific features as needed:

--- a/slaf/data/converter.py
+++ b/slaf/data/converter.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 from typing import Any
 
 import lance
@@ -30,6 +31,32 @@ except ImportError:
 
 from .chunked_reader import create_chunked_reader
 from .utils import discover_input_files, validate_input_files
+
+
+def _check_output_filesystem(output_path: str) -> None:
+    """Raise RuntimeError early if the output path does not support atomic renames.
+
+    Lance requires atomic rename support. ExFAT, FAT32, and NTFS on macOS do not
+    support this, producing a cryptic ``LanceError(IO): Unable to rename file``.
+    """
+    parent = output_path
+    while parent and not os.path.exists(parent):
+        parent = os.path.dirname(parent)
+    parent = parent or "."
+
+    try:
+        fd, src = tempfile.mkstemp(dir=parent)
+        os.close(fd)
+        dst = src + ".rename_test"
+        os.rename(src, dst)
+        os.unlink(dst)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Output path '{output_path}' is on a filesystem that does not support "
+            f"atomic renames (e.g. ExFAT, FAT32, NTFS on macOS). "
+            f"Please use a local POSIX-compatible path (e.g. APFS, HFS+, ext4), "
+            f"then copy the resulting .slaf directory to your destination if needed."
+        ) from exc
 
 
 class SLAFConverter:
@@ -442,6 +469,7 @@ class SLAFConverter:
             ...     print(f"Error: {e}")
             Error: Cannot detect format for: unknown_file.txt
         """
+        _check_output_filesystem(output_path)
         # Handle both single paths and lists of files
         if isinstance(input_path, list):
             # Direct list of files - use multi-file conversion

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import lance
 import numpy as np
@@ -2481,3 +2482,42 @@ class TestSpatialH5ADConversion:
             "tissue_hires_scalef"
         ] == pytest.approx(0.17)
         assert uns_data["spatial"]["library_id"]["metadata"]["chemistry"] == "Visium"
+
+
+class TestNonPosixFilesystemWarning:
+    """_check_output_filesystem raises a clear error on non-POSIX filesystems."""
+
+    def test_non_posix_rename_raises_runtime_error(self, small_sample_adata, tmp_path):
+        """convert() raises RuntimeError when os.rename fails (simulates ExFAT/NTFS)."""
+        h5ad_path = tmp_path / "data.h5ad"
+        small_sample_adata.write(h5ad_path)
+
+        with patch(
+            "slaf.data.converter.os.rename", side_effect=OSError("rename not supported")
+        ):
+            with pytest.raises(RuntimeError, match="atomic renames"):
+                converter = SLAFConverter(chunked=False, compact_after_write=False)
+                converter.convert(str(h5ad_path), str(tmp_path / "output.slaf"))
+
+    def test_posix_filesystem_does_not_raise(self, small_sample_adata, tmp_path):
+        """convert() proceeds normally on a POSIX-compatible filesystem (tmp_path is local APFS)."""
+        h5ad_path = tmp_path / "data.h5ad"
+        small_sample_adata.write(h5ad_path)
+        converter = SLAFConverter(
+            chunked=False,
+            use_optimized_dtypes=False,
+            compact_after_write=False,
+        )
+        converter.convert(str(h5ad_path), str(tmp_path / "output.slaf"))
+
+    def test_error_message_contains_suggested_workaround(
+        self, small_sample_adata, tmp_path
+    ):
+        """RuntimeError message tells the user to use a local POSIX path."""
+        h5ad_path = tmp_path / "data.h5ad"
+        small_sample_adata.write(h5ad_path)
+
+        with patch("slaf.data.converter.os.rename", side_effect=OSError):
+            with pytest.raises(RuntimeError, match="local"):
+                converter = SLAFConverter(chunked=False, compact_after_write=False)
+                converter.convert(str(h5ad_path), str(tmp_path / "output.slaf"))


### PR DESCRIPTION
## Summary

- Adds `_check_output_filesystem()` to `SLAFConverter.convert()` that probes the output parent directory with a `tempfile` + `os.rename` before any Lance writes
- If the probe fails (ExFAT, FAT32, NTFS on macOS), raises a `RuntimeError` with an actionable message directing the user to a local POSIX-compatible path
- No platform detection or subprocess calls — works on any OS/architecture

## Motivation

Lance requires atomic rename support for its commit protocol. Non-POSIX filesystems (ExFAT is common on external drives on macOS) do not support this, but the failure previously surfaced as a cryptic deep error:
```
LanceError(IO): Generic LocalFileSystem error: Unable to rename file: Operation not supported (os error 45)
```

Users have no indication that the output path is the problem.

## Test plan

- [ ] `test_non_posix_rename_raises_runtime_error` — mocks `os.rename` to fail, asserts `RuntimeError` with "atomic renames" in message
- [ ] `test_posix_filesystem_does_not_raise` — confirms normal POSIX path (pytest `tmp_path`) converts without error
- [ ] `test_error_message_contains_suggested_workaround` — asserts message contains "local"
- [ ] Full converter suite: 79 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)