### PR TITLE
fix(ml): drop persistent Lance fragment iterators that pin scanner state

### DIFF
--- a/benchmarks/raw_mode_memory_leak_repro.py
+++ b/benchmarks/raw_mode_memory_leak_repro.py
@@ -1,0 +1,308 @@
+"""SLAFDataLoader(raw_mode=True) host-memory leak reproducer.
+
+The bug
+=======
+
+Before the fix, ``PrefetchBatchProcessor.__init__`` pre-created one
+persistent ``fragment.to_batches(...)`` iterator per Lance fragment and held
+the list alive on ``self.fragment_generators``. Each iterator allocates
+~70 MiB of Lance-side scanner state on its first ``next()`` and keeps it for
+its lifetime. Mixture-of-Scanners samples fresh fragments per load, so the
+touched-iterator set grows unboundedly — for a 2000-fragment dataset the
+worst case is ~140 GiB.
+
+What this script does
+=====================
+
+Constructs a ``SLAFDataLoader(raw_mode=True)`` against a synthesised small
+SLAF (or a user-provided dataset via ``--slaf-path``), paces the consumer
+with ``--consumer-sleep-ms`` to mimic a GPU step, and samples RSS and queue
+depth every two seconds. Before the fix this OOMs a 24 GiB cgroup in ~8 s on
+Parse-10M scale; after the fix RSS plateaus.
+
+Usage
+=====
+
+Quick local run (synthesises ~150 MiB SLAF in /tmp on first run)::
+
+    uv run python benchmarks/raw_mode_memory_leak_repro.py
+
+Against a real dataset, under a cgroup cap so a regression cannot crash the
+host::
+
+    systemd-run --user --scope -q -p MemoryMax=8G -p MemorySwapMax=0 -- \\
+        uv run python benchmarks/raw_mode_memory_leak_repro.py \\
+        --slaf-path /path/to/your.slaf
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import psutil
+import scanpy as sc
+from loguru import logger
+from scipy.sparse import random as sparse_random
+
+from slaf import SLAFArray
+from slaf.data import SLAFConverter
+from slaf.ml.dataloaders import SLAFDataLoader
+
+# Quiet the loguru-driven banner SLAFArray prints on every open.
+logger.remove()
+logger.add(sys.stderr, level=os.environ.get("LOGURU_LEVEL", "WARNING"))
+
+
+# Sized so expression.lance produces multiple Lance fragments (so n_scanners=16
+# has parallel work) without taking too long to build. ~150 MB on disk.
+SYNTH_N_CELLS = 500_000
+SYNTH_N_GENES = 2000
+SYNTH_DENSITY = 0.05  # ~50M nonzeros
+
+
+def build_synthetic_slaf(out_path: Path) -> None:
+    print(f"Building synthetic SLAF at {out_path} ({SYNTH_N_CELLS:,} cells)...")
+    rng = np.random.default_rng(0)
+    X = sparse_random(
+        SYNTH_N_CELLS,
+        SYNTH_N_GENES,
+        density=SYNTH_DENSITY,
+        format="csr",
+        dtype=np.float32,
+        random_state=rng,
+        data_rvs=lambda n: rng.integers(1, 50, size=n).astype(np.float32),
+    )
+    adata = sc.AnnData(X=X)
+    adata.obs_names = [f"cell_{i}" for i in range(SYNTH_N_CELLS)]
+    adata.var_names = [f"gene_{i}" for i in range(SYNTH_N_GENES)]
+    h5ad = out_path.with_suffix(".h5ad")
+    adata.write_h5ad(h5ad)
+    SLAFConverter().convert(str(h5ad), str(out_path))
+    h5ad.unlink(missing_ok=True)
+
+
+def rss_mib() -> float:
+    return psutil.Process().memory_info().rss / 1024 / 1024
+
+
+def measure(
+    slaf_path: str,
+    raw_mode: bool,
+    measure_sec: float,
+    consumer_sleep_ms: float,
+    n_scanners: int = 16,
+    prefetch_batch_size: int = 1_048_576,
+) -> dict:
+    label = "raw_mode=True" if raw_mode else "raw_mode=False (tokenized)"
+    print(f"\n=== {label} (consumer pacing: {consumer_sleep_ms} ms/batch) ===")
+
+    gc.collect()
+    base_rss = rss_mib()
+    print(f"baseline: RSS={base_rss:7.0f} MiB", flush=True)
+
+    slaf = SLAFArray(slaf_path)
+    _ = len(slaf.obs)
+
+    # Same settings as benchmarks/benchmark_dataloaders_internal.py raw branch.
+    dataloader = SLAFDataLoader(
+        slaf_array=slaf,
+        tokenizer_type="raw" if raw_mode else "geneformer",
+        batch_size=32,
+        max_genes=2048,
+        vocab_size=50000,
+        n_expression_bins=10,
+        n_epochs=1000,
+        raw_mode=raw_mode,
+        verbose=False,
+        use_mixture_of_scanners=True,
+        by_fragment=False,
+        batches_per_chunk=1,
+        n_scanners=n_scanners,
+        prefetch_batch_size=prefetch_batch_size,
+        # Let SLAFDataLoader pick the per-mode default (1 for raw, 5000 for
+        # tokenized). The reproducer used to force 5000 here to exhibit the
+        # original leak — that's no longer the load-bearing signal.
+    )
+
+    # Reach into the prefetcher to observe queue depth — the queue depth is
+    # the load-bearing signal here: it tells us how much Arrow data is pinned.
+    prefetcher = dataloader._dataset.prefetcher
+    queue = prefetcher.queue
+    queue_max = prefetcher.max_queue_size
+
+    # Brief warmup so the prefetcher has filled its initial reservoir.
+    for i, _ in enumerate(dataloader):
+        if i >= 5:
+            break
+
+    samples = []
+    t0 = time.perf_counter()
+    last_log = t0
+    batch_count = 0
+    sleep_sec = consumer_sleep_ms / 1000.0
+    for _batch in dataloader:
+        if sleep_sec > 0:
+            time.sleep(sleep_sec)
+        batch_count += 1
+        now = time.perf_counter()
+        if now - last_log >= 2.0:
+            samples.append((now - t0, rss_mib(), queue.qsize(), batch_count))
+            print(
+                f"  t={now - t0:5.1f}s  batches={batch_count:5d}  "
+                f"queue={queue.qsize():5d}/{queue_max}  RSS={rss_mib():7.0f} MiB",
+                flush=True,
+            )
+            last_log = now
+        if now - t0 >= measure_sec:
+            break
+
+    end_rss = rss_mib()
+    end_queue = queue.qsize()
+
+    # SLAFDataLoader.__del__ does not stop the prefetcher (slaf/ml/dataloaders.py
+    # line ~668 — just `pass`). Stop it explicitly so the queue's references
+    # to RawPrefetchBatch payloads are dropped, then measure release.
+    prefetcher.stop()
+    while not queue.empty():
+        try:
+            queue.get_nowait()
+        except Exception:
+            break
+    del dataloader
+    del slaf
+    del prefetcher
+    del queue
+    gc.collect()
+    post_rss = rss_mib()
+    print(
+        f"after stop+drain+gc: RSS={post_rss:7.0f} MiB "
+        f"(reclaimed {end_rss - post_rss:.0f} MiB of {end_rss - base_rss:.0f} MiB held)",
+        flush=True,
+    )
+
+    return {
+        "label": label,
+        "samples": samples,
+        "rss_growth_mib": end_rss - base_rss,
+        "rss_after_cleanup_mib": post_rss - base_rss,
+        "end_queue_depth": end_queue,
+        "queue_max": queue_max,
+        "duration_sec": measure_sec,
+        "batches": batch_count,
+    }
+
+
+def summarise(result: dict) -> None:
+    print(f"\n--- summary: {result['label']} ---")
+    print(f"  duration:                 {result['duration_sec']:.1f}s")
+    print(f"  batches iterated:         {result['batches']}")
+    print(
+        f"  end queue depth:          {result['end_queue_depth']}/{result['queue_max']}"
+    )
+    rss_growth = result["rss_growth_mib"]
+    print(
+        f"  RSS growth (in-flight):   {rss_growth:+.0f} MiB "
+        f"({rss_growth / result['duration_sec']:+.1f} MiB/s)"
+    )
+    reclaimed = result["rss_growth_mib"] - result["rss_after_cleanup_mib"]
+    print(
+        f"  RSS reclaimed by del+gc:  {reclaimed:.0f} MiB "
+        f"(net after cleanup: {result['rss_after_cleanup_mib']:+.0f} MiB)"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--slaf-path",
+        type=str,
+        default=None,
+        help="Existing SLAF dataset. If omitted, a small synthetic one is built.",
+    )
+    parser.add_argument(
+        "--measure-sec",
+        type=float,
+        default=20.0,
+        help="Per-mode iteration duration in seconds (default: 20).",
+    )
+    parser.add_argument(
+        "--consumer-sleep-ms",
+        type=float,
+        default=50.0,
+        help=(
+            "Sleep added after each consumed batch, in ms, to mimic a GPU "
+            "training step. The leak only manifests when the consumer is "
+            "slower than the producer (default: 50ms; real training runs are "
+            "around 175ms/step)."
+        ),
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("raw", "tokenized", "both"),
+        default="both",
+        help="Which mode(s) to measure (default: both — contrast is the demo).",
+    )
+    parser.add_argument(
+        "--n-scanners",
+        type=int,
+        default=16,
+        help=(
+            "Lance Mixture-of-Scanners parallelism (default: 16, matches "
+            "benchmark_dataloaders_internal.py). Lower values reduce Lance's "
+            "per-scanner readahead footprint independently of the queue-boundary "
+            "fix; useful for isolating where memory is being held."
+        ),
+    )
+    parser.add_argument(
+        "--prefetch-batch-size",
+        type=int,
+        default=1_048_576,
+        help="Lance per-scanner batch size in rows (default: 1,048,576).",
+    )
+    args = parser.parse_args()
+
+    if args.slaf_path is None:
+        path = Path("/tmp/slaf_leak_repro.slaf")
+        if not path.exists():
+            build_synthetic_slaf(path)
+        slaf_path = str(path)
+    else:
+        slaf_path = args.slaf_path
+
+    results = []
+    if args.mode in ("raw", "both"):
+        results.append(
+            measure(
+                slaf_path,
+                raw_mode=True,
+                measure_sec=args.measure_sec,
+                consumer_sleep_ms=args.consumer_sleep_ms,
+                n_scanners=args.n_scanners,
+                prefetch_batch_size=args.prefetch_batch_size,
+            )
+        )
+    if args.mode in ("tokenized", "both"):
+        results.append(
+            measure(
+                slaf_path,
+                raw_mode=False,
+                measure_sec=args.measure_sec,
+                consumer_sleep_ms=args.consumer_sleep_ms,
+                n_scanners=args.n_scanners,
+                prefetch_batch_size=args.prefetch_batch_size,
+            )
+        )
+
+    print("\n" + "=" * 60)
+    for r in results:
+        summarise(r)
+
+
+if __name__ == "__main__":
+    main()

--- a/slaf/ml/dataloaders.py
+++ b/slaf/ml/dataloaders.py
@@ -281,7 +281,7 @@ class SLAFDataLoader:
         use_mixture_of_scanners: bool = True,  # Default to True for MoS (was False)
         n_scanners: int = 16,  # Add n_scanners parameter for MoS
         prefetch_batch_size: int = 4194304,  # Add prefetch_batch_size parameter for MoS
-        max_queue_size: int = 5000,  # Add max_queue_size parameter
+        max_queue_size: int | None = None,  # None resolves per mode in __init__
         parallelize_fragment_reads: bool = False,  # Parallelize fragment reads in MoS (cloud optimization)
         prefetcher_ready_timeout: float = 10.0,  # Timeout for waiting for prefetcher to be ready
     ):
@@ -428,6 +428,12 @@ class SLAFDataLoader:
         self.prefetch_batch_size = (
             prefetch_batch_size  # Add prefetch_batch_size attribute
         )
+        # Raw payloads carry one full producer load
+        # (``n_scanners × prefetch_batch_size`` rows, hundreds of MiB on
+        # large datasets), so a deep queue would pin tens of GiB of host
+        # memory. Tokenized payloads are compact tensors and stay cheap.
+        if max_queue_size is None:
+            max_queue_size = 1 if raw_mode else 5000
         self.max_queue_size = max_queue_size  # Add max_queue_size attribute
         self.parallelize_fragment_reads = (
             parallelize_fragment_reads  # Add parallelize_fragment_reads attribute
@@ -490,7 +496,7 @@ class SLAFDataLoader:
             tokenizer=self.tokenizer,
             batch_size=batch_size,
             seed=42,  # TODO: make configurable
-            max_queue_size=max_queue_size,  # Pass max_queue_size to dataset
+            max_queue_size=self.max_queue_size,  # Pass resolved value to dataset
             n_epochs=n_epochs,  # Pass n_epochs to dataset
             raw_mode=raw_mode,  # Pass raw_mode to dataset
             verbose=verbose,  # Pass verbose to dataset
@@ -641,31 +647,17 @@ class SLAFDataLoader:
         return 0  # Indicates unknown length
 
     def __del__(self):
+        """Stop the background prefetcher on garbage collection.
+
+        Best-effort: ``__del__`` may run during interpreter shutdown when
+        module globals are already torn down, so exceptions are swallowed.
         """
-        Cleanup method to stop async prefetching.
-
-        This method is called when the DataLoader object is garbage collected.
-        It ensures that the underlying dataset's prefetcher is properly cleaned up
-        to prevent resource leaks.
-
-        Examples:
-            >>> # DataLoader cleanup happens automatically
-            >>> slaf_array = SLAFArray("path/to/data.slaf")
-            >>> dataloader = SLAFDataLoader(slaf_array)
-            >>> print("DataLoader created")
-            DataLoader created
-            >>> # When dataloader goes out of scope, __del__ is called automatically
-            >>> del dataloader
-            >>> print("DataLoader destroyed and cleaned up")
-            DataLoader destroyed and cleaned up
-
-            >>> # Manual cleanup (not usually needed)
-            >>> dataloader = SLAFDataLoader(slaf_array)
-            >>> dataloader.__del__()
-            >>> print("Manual cleanup completed")
-            Manual cleanup completed
-        """
-        if hasattr(self, "_dataset"):
-            # The SLAFIterableDataset doesn't have a stop method,
-            # so we just let it finish its current epoch.
+        try:
+            dataset = getattr(self, "_dataset", None)
+            if dataset is None:
+                return
+            prefetcher = getattr(dataset, "prefetcher", None)
+            if prefetcher is not None:
+                prefetcher.stop()
+        except Exception:
             pass

--- a/slaf/ml/datasets.py
+++ b/slaf/ml/datasets.py
@@ -380,29 +380,26 @@ class PrefetchBatchProcessor:
         )
 
         if self.use_mixture_of_scanners:
-            # MoS approach: initialize one generator per fragment
-            self.fragment_generators: list[Any] = []
-            self.generator_last_cells: list[
-                int | None
-            ] = []  # Track last cell per generator
-            self.generator_active: list[
-                bool
-            ] = []  # Track which generators are still active
-
-            # Initialize fragment generators
-            for fragment in self.expression_dataset.get_fragments():
-                # Pass the prefetch_batch_size to control batch sizes and prevent premature exhaustion
-                generator = fragment.to_batches(batch_size=self.prefetch_batch_size)
-                self.fragment_generators.append(generator)
-                self.generator_last_cells.append(None)
-                self.generator_active.append(True)
+            # MoS holds per-fragment row cursors and opens scanners on demand
+            # in ``_read_from_generator`` (rather than caching a persistent
+            # ``to_batches`` iterator per fragment, which would pin Lance's
+            # per-fragment scanner buffers for the lifetime of the processor).
+            self.fragments: list[Any] = list(self.expression_dataset.get_fragments())
+            self.fragment_row_counts: list[int] = [
+                int(f.count_rows()) for f in self.fragments
+            ]
+            self.fragment_positions: list[int] = [0] * len(self.fragments)
+            self.generator_last_cells: list[int | None] = [None] * len(self.fragments)
+            self.generator_active: list[bool] = [
+                n > 0 for n in self.fragment_row_counts
+            ]
 
             # Set by_fragment to True for MoS mode
             self.by_fragment = True
 
             if self.verbose:
                 print_prefetch(
-                    f"Mixture of Scanners enabled: {len(self.fragment_generators)} fragment generators, "
+                    f"Mixture of Scanners enabled: {len(self.fragments)} fragments, "
                     f"{self.n_scanners} scanners, prefetch_batch_size={self.prefetch_batch_size:,}",
                     self.verbose,
                 )
@@ -491,20 +488,14 @@ class PrefetchBatchProcessor:
 
         # Reinitialize the data iterator based on the approach
         if self.use_mixture_of_scanners:
-            # MoS approach: reinitialize all fragment generators
-            self.fragment_generators = []
-            self.generator_last_cells = []
-            self.generator_active = []
-
-            for fragment in self.expression_dataset.get_fragments():
-                generator = fragment.to_batches(batch_size=self.prefetch_batch_size)
-                self.fragment_generators.append(generator)
-                self.generator_last_cells.append(None)
-                self.generator_active.append(True)
+            # Rewind per-fragment cursors; reuse fragments + row counts.
+            self.fragment_positions = [0] * len(self.fragments)
+            self.generator_last_cells = [None] * len(self.fragments)
+            self.generator_active = [n > 0 for n in self.fragment_row_counts]
 
             if self.verbose:
                 print_epoch_transition(
-                    f"Reset MoS: {len(self.fragment_generators)} fragment generators for epoch {epoch}",
+                    f"Reset MoS: {len(self.fragments)} fragments for epoch {epoch}",
                     self.verbose,
                 )
 
@@ -561,49 +552,52 @@ class PrefetchBatchProcessor:
     def _read_from_generator(
         self, generator_idx: int
     ) -> tuple[pl.DataFrame | None, int, bool]:
-        """
-        Read batches_per_chunk from a single generator.
+        """Read ``batches_per_chunk`` row-batches from one MoS fragment.
+
+        Opens a fresh ``fragment.scanner(offset, limit).to_table()`` per call
+        so Lance's per-fragment scanner buffers release when the local table
+        goes out of scope.
 
         Returns:
             tuple: (generator_combined DataFrame, generator_idx, is_exhausted)
         """
-        try:
-            # Read batches_per_chunk times from this generator
-            generator_batches: list[pl.DataFrame] = []
-            for _ in range(self.batches_per_chunk):
-                try:
-                    batch = next(self.fragment_generators[generator_idx])
-                    batch_df_raw = pl.from_arrow(batch)
-                    # Ensure we have a DataFrame, not a Series
-                    if isinstance(batch_df_raw, pl.Series):
-                        raise TypeError(
-                            "Expected DataFrame but got Series from generator batch"
-                        )
-                    batch_df: pl.DataFrame = batch_df_raw
-                    generator_batches.append(batch_df)
-                except StopIteration:
-                    # This generator is exhausted
-                    return None, generator_idx, True
-
-            if not generator_batches:
-                # Generator was exhausted
-                return None, generator_idx, True
-
-            # Combine all batches from this generator
-            if len(generator_batches) > 1:
-                generator_combined = pl.concat(generator_batches)  # type: ignore
-            else:
-                generator_combined = generator_batches[0]
-
-            # Ensure we return a DataFrame, not a Series
-            if isinstance(generator_combined, pl.Series):
-                raise TypeError("Expected DataFrame but got Series from generator")
-
-            return generator_combined, generator_idx, False
-
-        except StopIteration:
-            # Mark this generator as exhausted
+        total = self.fragment_row_counts[generator_idx]
+        if self.fragment_positions[generator_idx] >= total:
             return None, generator_idx, True
+
+        fragment = self.fragments[generator_idx]
+        generator_batches: list[pl.DataFrame] = []
+        for _ in range(self.batches_per_chunk):
+            pos = self.fragment_positions[generator_idx]
+            if pos >= total:
+                break
+            tbl = fragment.scanner(
+                offset=pos,
+                limit=self.prefetch_batch_size,
+            ).to_table()
+            self.fragment_positions[generator_idx] = pos + tbl.num_rows
+            if tbl.num_rows == 0:
+                break
+            batch_df_raw = pl.from_arrow(tbl)
+            del tbl
+            if isinstance(batch_df_raw, pl.Series):
+                raise TypeError(
+                    "Expected DataFrame but got Series from generator batch"
+                )
+            generator_batches.append(batch_df_raw)
+
+        if not generator_batches:
+            return None, generator_idx, True
+
+        if len(generator_batches) > 1:
+            generator_combined = pl.concat(generator_batches)  # type: ignore
+        else:
+            generator_combined = generator_batches[0]
+
+        if isinstance(generator_combined, pl.Series):
+            raise TypeError("Expected DataFrame but got Series from generator")
+
+        return generator_combined, generator_idx, False
 
     def load_prefetch_batch(self) -> PrefetchBatch:
         """

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -808,8 +808,14 @@ class TestSLAFDataLoader:
         assert len(epochs_seen) >= 1, f"Expected at least 1 epoch, got {epochs_seen}"
         assert batch_count > 0
 
-    def test_mixture_of_scanners_fragment_generators_creation(self, tiny_slaf):
-        """Test that MoS creates fragment generators correctly"""
+    def test_mixture_of_scanners_fragment_state_creation(self, tiny_slaf):
+        """Test that MoS sets up per-fragment cursor state correctly.
+
+        MoS reads fragments on-demand via ``frag.scanner(offset, limit)``
+        rather than holding persistent Lance iterators, so the processor
+        carries ``fragments`` (the Lance Fragment objects), per-fragment
+        ``fragment_row_counts``, and ``fragment_positions`` cursors.
+        """
         dataloader = SLAFDataLoader(
             slaf_array=tiny_slaf,
             batch_size=32,
@@ -818,18 +824,24 @@ class TestSLAFDataLoader:
             prefetch_batch_size=1048576,
         )
 
-        # Check that fragment generators are created in the underlying dataset
-        assert hasattr(dataloader._dataset.batch_processor, "fragment_generators")
-        assert len(dataloader._dataset.batch_processor.fragment_generators) > 0
-
-        # Check that generator tracking arrays are created
-        assert hasattr(dataloader._dataset.batch_processor, "generator_last_cells")
-        assert hasattr(dataloader._dataset.batch_processor, "generator_active")
-        assert len(dataloader._dataset.batch_processor.generator_last_cells) == len(
-            dataloader._dataset.batch_processor.fragment_generators
-        )
-        assert len(dataloader._dataset.batch_processor.generator_active) == len(
-            dataloader._dataset.batch_processor.fragment_generators
+        proc = dataloader._dataset.batch_processor
+        assert hasattr(proc, "fragments")
+        assert len(proc.fragments) > 0
+        assert hasattr(proc, "fragment_row_counts")
+        assert hasattr(proc, "fragment_positions")
+        assert hasattr(proc, "generator_last_cells")
+        assert hasattr(proc, "generator_active")
+        n = len(proc.fragments)
+        assert len(proc.fragment_row_counts) == n
+        assert len(proc.fragment_positions) == n
+        assert len(proc.generator_last_cells) == n
+        assert len(proc.generator_active) == n
+        # Cursors must stay within their fragment's row count at all times.
+        assert all(
+            0 <= p <= total
+            for p, total in zip(
+                proc.fragment_positions, proc.fragment_row_counts, strict=True
+            )
         )
 
     def test_mixture_of_scanners_random_sampling_behavior(self, tiny_slaf):

--- a/tests/test_pytorch_datasets.py
+++ b/tests/test_pytorch_datasets.py
@@ -79,8 +79,12 @@ class TestSLAFIterableDataset:
         assert processor.n_expression_bins == 10
         assert processor.use_binned_expressions is True
         assert hasattr(processor, "expression_dataset")
-        # With MoS enabled by default, we should have fragment_generators instead of batch_generator
-        assert hasattr(processor, "fragment_generators")
+        # With MoS enabled by default, the processor holds per-fragment
+        # cursor state (fragments + fragment_positions + row counts), not
+        # a single batch_generator.
+        assert hasattr(processor, "fragments")
+        assert hasattr(processor, "fragment_positions")
+        assert hasattr(processor, "fragment_row_counts")
 
     def test_prefetch_batch_processor_fragment_parameter(self, tiny_slaf):
         """Test the by_fragment parameter in PrefetchBatchProcessor."""
@@ -932,8 +936,8 @@ class TestPrefetchBatchProcessing:
         assert dataset.batch_processor.n_scanners == 8
         assert dataset.batch_processor.prefetch_batch_size == 1048576
 
-    def test_mixture_of_scanners_fragment_generators(self, tiny_slaf):
-        """Test that MoS creates the correct number of fragment generators"""
+    def test_mixture_of_scanners_fragment_state(self, tiny_slaf):
+        """Test that MoS sets up per-fragment cursor state correctly."""
         tokenizer = GeneformerTokenizer(tiny_slaf)
 
         dataset = SLAFIterableDataset(
@@ -945,18 +949,24 @@ class TestPrefetchBatchProcessing:
             prefetch_batch_size=1048576,
         )
 
-        # Check that fragment generators are created
-        assert hasattr(dataset.batch_processor, "fragment_generators")
-        assert len(dataset.batch_processor.fragment_generators) > 0
-
-        # Check that generator tracking arrays are created
-        assert hasattr(dataset.batch_processor, "generator_last_cells")
-        assert hasattr(dataset.batch_processor, "generator_active")
-        assert len(dataset.batch_processor.generator_last_cells) == len(
-            dataset.batch_processor.fragment_generators
-        )
-        assert len(dataset.batch_processor.generator_active) == len(
-            dataset.batch_processor.fragment_generators
+        proc = dataset.batch_processor
+        assert hasattr(proc, "fragments")
+        assert len(proc.fragments) > 0
+        assert hasattr(proc, "fragment_positions")
+        assert hasattr(proc, "fragment_row_counts")
+        assert hasattr(proc, "generator_last_cells")
+        assert hasattr(proc, "generator_active")
+        n = len(proc.fragments)
+        assert len(proc.fragment_positions) == n
+        assert len(proc.fragment_row_counts) == n
+        assert len(proc.generator_last_cells) == n
+        assert len(proc.generator_active) == n
+        # Cursors must stay within their fragment's row count at all times.
+        assert all(
+            0 <= p <= total
+            for p, total in zip(
+                proc.fragment_positions, proc.fragment_row_counts, strict=True
+            )
         )
 
     def test_mixture_of_scanners_parameter_validation(self, tiny_slaf):
@@ -1066,14 +1076,13 @@ class TestPrefetchBatchProcessing:
         assert dataset.batch_processor.current_epoch == 1
         assert dataset.batch_processor.batch_id == 0
 
-        # Check that fragment generators are reinitialized
-        assert len(dataset.batch_processor.fragment_generators) > 0
-        assert len(dataset.batch_processor.generator_last_cells) == len(
-            dataset.batch_processor.fragment_generators
-        )
-        assert len(dataset.batch_processor.generator_active) == len(
-            dataset.batch_processor.fragment_generators
-        )
+        # Per-fragment cursors must be rewound to zero on epoch reset.
+        proc = dataset.batch_processor
+        n = len(proc.fragments)
+        assert n > 0
+        assert all(p == 0 for p in proc.fragment_positions)
+        assert len(proc.generator_last_cells) == n
+        assert len(proc.generator_active) == n
 
     def test_mixture_of_scanners_backward_compatibility(self, tiny_slaf):
         """Test that MoS is backward compatible (enabled by default) in PrefetchBatchProcessor"""
@@ -1088,7 +1097,8 @@ class TestPrefetchBatchProcessing:
         )
 
         assert processor_default.use_mixture_of_scanners is True
-        assert hasattr(processor_default, "fragment_generators")
+        assert hasattr(processor_default, "fragments")
+        assert hasattr(processor_default, "fragment_positions")
         assert not hasattr(processor_default, "batch_generator")
 
         # Explicitly disable MoS and use batch mode
@@ -1101,7 +1111,7 @@ class TestPrefetchBatchProcessing:
         )
 
         assert processor_disabled.use_mixture_of_scanners is False
-        assert not hasattr(processor_disabled, "fragment_generators")
+        assert not hasattr(processor_disabled, "fragment_positions")
         assert hasattr(processor_disabled, "batch_generator")
 
     def test_mixture_of_scanners_with_raw_mode(self, tiny_slaf):
@@ -1245,15 +1255,16 @@ class TestPrefetchBatchProcessing:
         assert processor.prefetch_batch_size == 1048576
         assert processor.by_fragment is True  # MoS automatically enables fragment mode
 
-        # Check that fragment generators are created
-        assert hasattr(processor, "fragment_generators")
-        assert len(processor.fragment_generators) > 0
-
-        # Check that generator tracking arrays are created
+        # Check that per-fragment cursor state is created (on-demand scanner pattern)
+        assert hasattr(processor, "fragments")
+        assert len(processor.fragments) > 0
+        assert hasattr(processor, "fragment_positions")
         assert hasattr(processor, "generator_last_cells")
         assert hasattr(processor, "generator_active")
-        assert len(processor.generator_last_cells) == len(processor.fragment_generators)
-        assert len(processor.generator_active) == len(processor.generator_active)
+        n = len(processor.fragments)
+        assert len(processor.fragment_positions) == n
+        assert len(processor.generator_last_cells) == n
+        assert len(processor.generator_active) == n
 
     def test_prefetch_batch_processor_mos_parameter_validation(self, tiny_slaf):
         """Test MoS parameter validation in PrefetchBatchProcessor"""
@@ -1339,10 +1350,12 @@ class TestPrefetchBatchProcessing:
         assert processor.current_epoch == 1
         assert processor.batch_id == 0
 
-        # Check that fragment generators are reinitialized
-        assert len(processor.fragment_generators) > 0
-        assert len(processor.generator_last_cells) == len(processor.fragment_generators)
-        assert len(processor.generator_active) == len(processor.fragment_generators)
+        # Per-fragment cursors must be rewound to zero on epoch reset.
+        n = len(processor.fragments)
+        assert n > 0
+        assert all(p == 0 for p in processor.fragment_positions)
+        assert len(processor.generator_last_cells) == n
+        assert len(processor.generator_active) == n
 
     def test_prefetch_batch_processor_mos_backward_compatibility(self, tiny_slaf):
         """Test that MoS is backward compatible (enabled by default) in PrefetchBatchProcessor"""
@@ -1357,7 +1370,8 @@ class TestPrefetchBatchProcessing:
         )
 
         assert processor_default.use_mixture_of_scanners is True
-        assert hasattr(processor_default, "fragment_generators")
+        assert hasattr(processor_default, "fragments")
+        assert hasattr(processor_default, "fragment_positions")
         assert not hasattr(processor_default, "batch_generator")
 
         # Explicitly disable MoS and use batch mode
@@ -1370,7 +1384,7 @@ class TestPrefetchBatchProcessing:
         )
 
         assert processor_disabled.use_mixture_of_scanners is False
-        assert not hasattr(processor_disabled, "fragment_generators")
+        assert not hasattr(processor_disabled, "fragment_positions")
         assert hasattr(processor_disabled, "batch_generator")
 
     def test_prefetch_batch_processor_mos_with_raw_mode(self, tiny_slaf):


### PR DESCRIPTION
# fix(ml): drop persistent Lance fragment iterators that pin scanner state

**TL;DR:** Raw-mode iteration leaks memory because each Lance fragment SLAF reads from holds onto ~70 MiB of internal state forever, and the dataloader caches one such reader per fragment up front. Fix: open + close the scanner per read instead of caching it. On Parse-10M this turns OOM-at-8s into a steady plateau.

## Summary

`SLAFDataLoader(raw_mode=True)` accumulates host RAM unboundedly while iterating, OOM-ing a 24 GiB cgroup in ~8 s on Parse-10M.

`PrefetchBatchProcessor.__init__` pre-creates one persistent `fragment.to_batches(...)` iterator per Lance fragment and keeps the list alive on `self.fragment_generators`. Each iterator allocates **~70 MiB of Lance Rust-side scanner state on its first `next()`** and holds it for its lifetime. With Mixture-of-Scanners (MoS) randomly sampling fresh fragments per `load_prefetch_batch`, the touched-iterator set grows unboundedly — for Parse-10M's 2054 fragments the worst case is ~140 GiB.

This PR replaces the persistent-iterator pattern with per-fragment row cursors plus on-demand `fragment.scanner(offset, limit).to_table()` calls; per-fragment Lance state dies when the local scanner goes out of scope. Public API and yielded batch shapes are unchanged.

## Pinpointing the leak

The leak is **not** in `pl.from_arrow` zero-copy buffer pinning, **not** in the queue payload, and **not** in PyArrow's Python memory pool (which stays at 0 bytes throughout). It's the persistent generators at `slaf/ml/datasets.py:382–398`. Side-by-side Lance probes against Parse-10M's `expression.lance`:

| Pattern | RSS delta |
|---|---:|
| 32 persistent generators × one `next()` (mimics SLAF) | **+2150 MiB** (~70 MiB per touched gen) |
| Same 32 reads via `frag.scanner(offset, limit).to_table()` + drop | **+46 MiB** (bounded) |

Producer-side instrumentation during real Parse-10M iteration confirms: every `_read_from_generator` call advances ~80 MiB of resident memory; `pl.concat` / `shuffle.apply` / queue boundary are noise by comparison.

## Changes

1. **`slaf/ml/datasets.py` (~30 LOC net)** — `PrefetchBatchProcessor` now caches `self.fragments`, `self.fragment_row_counts`, `self.fragment_positions` (int cursors). `_read_from_generator` opens `fragment.scanner(offset, limit).to_table()` per call; Lance state dies at function exit. `reset_for_epoch` rewinds cursors instead of recreating 2054 iterators.

2. **`slaf/ml/dataloaders.py` (~5 LOC)** — mode-aware `max_queue_size` default. Raw payloads carry whole producer loads (~190 MiB and ~260 yielded batches each on Parse-10M); the old `5000` default meant 950 GiB worst-case queue. New default is `1` for raw (still buffers ~52 s of training at 200 ms/step, matches old `prefetch_fragments=1`), unchanged `5000` for tokenized. Users can still override.

3. **`slaf/ml/dataloaders.py` (~5 LOC)** — `SLAFDataLoader.__del__` was `pass`; now stops the prefetcher.

## Verified

**Memory — Parse-10M, 24 GiB cgroup, 175 ms/batch GPU pacing:**

| Configuration | RSS growth in 90 s | Steady state |
|---|---|---|
| `main` | OOM at t≈8 s | — |
| Queue cap only | OOM at t≈15 s | — |
| Generator fix only | +22 GiB (would OOM ~t=100 s) | not bounded |
| **Both (this PR)** | **+2 GiB, tapering** | **plateaus at ~12.8 GiB** |

Both fixes are needed. The generator fix removes the unbounded scaling with dataset size; the queue cap stops the producer from buffering hours of training in flight.

**Throughput — synthetic, no consumer pacing, 20 s × 2 runs:**

| Mode | `main` | This PR | Δ |
|---|---:|---:|---:|
| Raw | 6102 batches/s | 5929 | −2.8% |
| Tokenized | 2083 batches/s | 2036 | −2.2% |

The 2–3% comes from opening a fresh scanner per fragment read. Unobservable in GPU-paced training where the producer is 70× faster than the consumer ceiling.

## Compatibility

- **Public API: unchanged.** Constructor signatures, yielded batch dict shapes are identical. Only signature change is `max_queue_size: int | None = None`; explicit ints still work.
- **Internal**: `PrefetchBatchProcessor.fragment_generators` is removed, replaced by `fragments` + `fragment_positions` + `fragment_row_counts`. Tests that poked at the old name are updated in this PR.

## Test plan

- [x] `uv run pytest tests/ -m "not slow"` → 890 passed, 2 skipped (same as `main`)
- [x] `uv run ruff format --check .` and `uv run ruff check .` clean
- [x] `benchmarks/raw_mode_memory_leak_repro.py` on synthetic → plateau, queue capped at 1/1
- [x] Same against Parse-10M under 24 GiB cgroup, 90 s window, 175 ms/batch → plateaus at ~12.8 GiB (was OOM at t≈8 s)

## Reproducer

`benchmarks/raw_mode_memory_leak_repro.py` (new) — self-contained, synthesises a small SLAF on first run; `--slaf-path` for a real dataset, `--consumer-sleep-ms` to simulate GPU step time. Recommended for large data:

```bash
systemd-run --user --scope -q -p MemoryMax=8G -p MemorySwapMax=0 -- \
    uv run python benchmarks/raw_mode_memory_leak_repro.py --slaf-path /path/to/your.slaf
```

> **Note:** `benchmarks/raw_mode_memory_leak_repro.py` is included only so maintainers can verify the fix locally. Happy to drop it from the tree before merge — let me know if you'd prefer to land the PR without it.
