### PR TITLE
fix(scanpy): accept flavor kwarg in highly_variable_genes

### DIFF
--- a/slaf/integrations/scanpy.py
+++ b/slaf/integrations/scanpy.py
@@ -934,6 +934,7 @@ class LazyPreprocessing:
         min_disp: float = 0.5,
         max_disp: float = np.inf,
         n_top_genes: int | None = None,
+        flavor: str = "seurat",
         inplace: bool = True,
     ) -> pd.DataFrame | None:
         """
@@ -951,6 +952,10 @@ class LazyPreprocessing:
             max_disp: Maximum dispersion for genes to be considered.
             n_top_genes: Number of top genes to select by dispersion.
                         If specified, overrides min_disp and max_disp criteria.
+            flavor: HVG selection method. Only "seurat" (mean/dispersion-based
+                   selection over the full expression matrix) is currently
+                   implemented. Other scanpy flavors (e.g. "seurat_v3",
+                   "cell_ranger") are not yet supported.
             inplace: Whether to modify the adata object in place. Currently not
                     fully implemented - returns None when True.
 
@@ -959,6 +964,7 @@ class LazyPreprocessing:
                                 and highly_variable column. If inplace=True, returns None.
 
         Raises:
+            NotImplementedError: If `flavor` is not "seurat".
             RuntimeError: If the SLAF array is not properly initialized.
 
         Examples:
@@ -985,6 +991,12 @@ class LazyPreprocessing:
             >>> print(f"Top genes selected: {hvg_stats['highly_variable'].sum()}")
             Top genes selected: 1000
         """
+
+        if flavor != "seurat":
+            raise NotImplementedError(
+                f"highly_variable_genes(flavor={flavor!r}) is not implemented; "
+                "only flavor='seurat' (the default) is currently supported."
+            )
 
         # Calculate gene statistics via SQL using simple aggregation (no JOINs)
         stats_sql = """

--- a/tests/test_scanpy.py
+++ b/tests/test_scanpy.py
@@ -340,6 +340,27 @@ class TestLazyPreprocessingCorrectness:
         assert all(hvg_result["variance"] >= 0)
         assert all(hvg_result["dispersion"] >= 0)
 
+    def test_highly_variable_genes_flavor_seurat_default(self, tiny_slaf):
+        """flavor='seurat' (scanpy's default) should be accepted and behave as before"""
+        lazy_adata = LazyAnnData(tiny_slaf)
+
+        hvg_result = pp.highly_variable_genes(
+            lazy_adata, flavor="seurat", inplace=False
+        )
+
+        assert hvg_result is not None
+        assert "highly_variable" in hvg_result.columns
+
+    def test_highly_variable_genes_flavor_unsupported_raises(self, tiny_slaf):
+        """An unsupported flavor should raise a clear NotImplementedError,
+        not a TypeError about an unexpected keyword argument"""
+        lazy_adata = LazyAnnData(tiny_slaf)
+
+        with pytest.raises(NotImplementedError, match="seurat_v3"):
+            pp.highly_variable_genes(
+                lazy_adata, flavor="seurat_v3", n_top_genes=10, inplace=False
+            )
+
     def test_normalize_total_placeholder(self, tiny_slaf):
         """Test normalize_total placeholder implementation"""
         lazy_adata = LazyAnnData(tiny_slaf)


### PR DESCRIPTION
## Summary

`LazyPreprocessing.highly_variable_genes` had no `flavor` parameter at all. Any caller
that passes `flavor=` — including scanpy's own default of `flavor='seurat'` — hits:

```
TypeError: LazyPreprocessing.highly_variable_genes() got an unexpected keyword argument 'flavor'
```

This makes the function fail for code written against scanpy's
[`pp.highly_variable_genes`](https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.highly_variable_genes.html)
signature even when it only asks for the default flavor.

## Changes

- Add `flavor: str = "seurat"` to the signature, matching scanpy's default and the
  existing mean/dispersion-based implementation here.
- Raise `NotImplementedError` with a clear message for any other flavor (`"cell_ranger"`,
  `"seurat_v3"`, `"seurat_v3_paper"`, etc.) instead of an unrelated `TypeError`. Per the
  scanpy docs, `seurat_v3`/`seurat_v3_paper` are a different algorithm entirely (variance-based
  selection on raw counts, requiring `n_top_genes` and the `scikit-misc` dependency) — out of
  scope for this fix, tracked separately.
- Two new tests: `flavor="seurat"` is accepted and behaves as before, and an unsupported
  flavor raises `NotImplementedError` (not `TypeError`).

## Note on `flavor="seurat"` fidelity

This PR does not change the underlying algorithm — it remains a raw per-gene
mean/dispersion calculation via SQL aggregation, without scanpy's binned
dispersion-normalization step (`FindVariableFeatures(..., method="mean.var.plot")`).
That's a pre-existing difference from scanpy's `"seurat"` flavor, unrelated to this
`flavor`-kwarg fix.

## Test plan

- [x] `pytest tests/test_scanpy.py -k highly_variable` — 6/6 passed
- [x] `pytest tests/test_scanpy.py` — 39/39 passed (no regressions)